### PR TITLE
Simplify refresh PR title; post a per-collection table as the body

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Refresh catalog from S3 holdings
         id: refresh
         run: |
-          ARGS="--summary refresh_summary.json"
+          ARGS="--summary refresh_summary.json --pr-body pr_body.md"
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS="$ARGS --dry-run"
           fi
@@ -86,18 +86,8 @@ jobs:
             collections.txt
           branch: update-catalog
           delete-branch: true
-          commit-message: "Refresh catalog: ${{ steps.refresh.outputs.changelog }}"
-          title: "Update catalog (${{ steps.refresh.outputs.changelog }})"
-          body: |
-            Automated weekly run of `pixi run refresh` (S3 diff, incremental
-            rebuild, prune, HEAD validation -- see `scripts/refresh_catalog.py`).
-
-            ```
-            ${{ steps.refresh.outputs.changelog }}
-            ```
-
-            Catalog items after refresh: ${{ steps.refresh.outputs.n_items }}.
-            Full diff summary in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-            After merging, `release.yml` (monthly cron, or run it manually via
-            workflow_dispatch) rebuilds `catalog.parquet`/`catalog.gti` and
-            publishes a dated release.
+          commit-message: "Refresh catalog: ${{ steps.refresh.outputs.subject }}"
+          title: "Update catalog (${{ steps.refresh.outputs.title }})"
+          # rendered by refresh_catalog.py --pr-body: headline counts plus a
+          # per-collection table (too long for a GITHUB_OUTPUT variable)
+          body-path: pr_body.md

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.geoparquet
 *.parquet
 refresh_summary.json
+pr_body.md
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,71 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## Which files to consider
 
 Only consider tracked files in the repository. Do not consider untracked files, even if they are in the same directory as tracked files.
 
 ## Python Environment
+
 Always use `pixi run python ...` when running Python commands. Do NOT create virtual environments (no `python -m venv`, `conda create`, `uv venv`, etc.). All Python execution should go through pixi.
+
+## Commands
+
+Defined as pixi tasks in `pixi.toml` (`pixi task list` shows descriptions):
+
+```bash
+pixi run create-stac --project WA_KingCounty_2021_B21 --overwrite  # one project (or --workunit)
+pixi run create-all                # every S3 project folder not already in catalog/
+pixi run refresh --dry-run         # diff catalog/ vs S3, report only
+pixi run refresh                   # diff + rebuild/prune + validate (mutates catalog/)
+ulimit -n 500000 && pixi run catalog2geoparquet   # full catalog -> catalog.parquet
+pixi run collection2geoparquet catalog/<ID>/collection.json out.parquet
+pixi run update-root-catalog       # link new children into catalog/catalog.json
+pixi run list-collections          # regenerate collections.txt
+pixi run ruff                      # ruff check --fix + ruff format
+```
+
+There is no test suite. `catalog2geoparquet` opens one file handle per item (~124k), hence the `ulimit -n` bump.
+
+Local `refresh` runs abort *after* modifying the working tree if validation fails (CI gates the commit separately, so nothing is published there). Recover with:
+`git restore catalog collections.txt && git clean -fd catalog`
+
+## Architecture
+
+The repository *is* the product: `catalog/` holds ~124k committed STAC Item JSONs (one per USGS 3DEP 1m GeoTIFF) plus a `collection.json` per project. `catalog.parquet` / `catalog.gti` are never committed (gitignored) — they are built in CI and published as release assets.
+
+Data flow:
+
+1. **S3 listing** — `s3://prd-tnm/StagedProducts/Elevation/1m/Projects/<project>/TIFF/*.tif`, unsigned boto3, **always paginated** (a bare `list_objects_v2` truncates at 1000 keys and has silently dropped tiles from large projects before). Tile lists come from listing `TIFF/` directly, *not* from `0_file_download_links.txt` — that file is missing for some projects and contains duplicates/wrong case in others.
+2. **STAC Item generation** — `scripts/create_static_stac.py` POSTs each TIFF URL to a TiTiler `/cog/stac` endpoint (currently a private Lambda URL constant in the script; `titiler.xyz` is rate limited). Requests are batched async (100 at a time) with bounded retries. Two known server responses are handled specially: "Too many bins for data range" → retry with `with_raster=false`; 5xx → short sleep and retry.
+3. **Collection metadata** — joined from USGS `WESM.csv` (`s3://prd-tnm/StagedProducts/Elevation/metadata/WESM.csv`) and attached to `collection.summaries` with a `wesm:` prefix (technically invalid STAC, but STAC Browser renders it). Layout is flat/self-contained (`TemplateLayoutStrategy(item_template="")`, `CatalogType.SELF_CONTAINED`) so `catalog/` is relocatable.
+4. **Aggregation** — `catalog2geoparquet.py` walks the root catalog with `rustac` and writes zstd STAC-GeoParquet; `collection2geoparquet.py` embeds collection metadata for a single collection. `update_root_catalog.py` adds child links and regenerates the `catalog/collection.json` "All Cataloged" meta collection (union bbox + temporal extent across all collections).
+
+### Project vs. workunit naming
+
+The S3 folder name is sometimes the WESM *project*, sometimes the *workunit*, and sometimes neither. Callers try `--workunit` first, then fall back to `--project` (see `create_all.py` and `refresh_catalog.py:build_project`). Irreconcilable names live in the hand-curated `onemeter_folder_to_wesm` dict in `create_static_stac.py` — a build failure in CI usually means a new folder needs an entry there. When a project spans multiple workunits (~214 of 909 collections), `collapse_workunit_rows` takes min(collect_start)/max(collect_end) rather than an order-dependent `.iloc[0]`.
+
+Some folders have no TIFFs at all; those are listed in `NO_TIFFS` in `create_all.py`. `NOTES.md` records the upstream quirks behind these workarounds — read it before "fixing" something that looks anomalous.
+
+### Schema uniformity
+
+`normalize_projection()` rewrites projection extension v1.x (`proj:epsg`) to v2.0.0 (`proj:code`) so the whole catalog — and therefore the GeoParquet column schema — stays uniform regardless of which TiTiler version answered. Anything that changes Item properties has to keep all ~124k items consistent or the parquet build produces a mixed schema.
+
+### Automation
+
+* `.github/workflows/update-catalog.yml` — weekly (Mon 06:00 UTC) + `workflow_dispatch` (`dry_run`, `allow_large_removals`). Runs `pixi run refresh` and opens a PR; no PR when nothing changed.
+* `.github/workflows/release.yml` — monthly (1st, 06:17 UTC) + dispatch. Skips if `catalog/` is unchanged since the latest release *tag* (resolved via the tag, not `targetCommitish`). Otherwise rebuilds the parquet, asserts parquet row count == item-file count, writes `catalog.gti`, and publishes a CalVer `vYYYY.MM.DD` release so `releases/latest/download/catalog.parquet` stays current.
+
+`refresh_catalog.py` is the interesting one — it is destructive by design and its guardrails exist because the USGS bucket has been observed mid-repopulation (issue #6):
+
+* abort if S3 lists < `--min-projects` (900) folders;
+* abort if the diff would remove > `--max-removed-tiles` (2000) tiles, unless `--allow-large-removals`;
+* a cataloged project whose `TIFF/` went empty is pruned **only** if the folder prefix is gone, or every probed item URL returns 404 — a 200, a probe error, or nothing to probe means carry unchanged and re-decide next run. Never make pruning fire on network errors.
+* new/changed item URLs must all HEAD 200; a random sample of *untouched* carried-over items must 404 below `--max-404-pct`.
+
+Tiles removed in place also need their item JSONs unlinked explicitly after a rebuild, otherwise the same projects are flagged changed every run and the parquet row-count gate diverges.
+
+## Consumers
+
+The published `catalog.parquet` feeds GDAL's [GTI driver](https://gdal.org/en/stable/drivers/raster/gti.html) and SlideRule Earth raster sampling, and is rendered by stac-map from `raw.githubusercontent`. Release assets redirect, so stac-map cannot read them — large parquet files for browsing live in the separate `scottyhq/files` repo. Keep this in mind before changing asset names, the `assets.elevation.href` field (the GTI `LocationField`), or the release asset filenames.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ pixi run refresh --dry-run   # report the diff only
 pixi run refresh             # apply it
 ```
 
+To preview the pull request body the workflow would post (headline counts plus a
+per-collection table of added/removed tiles), without touching the catalog:
+
+```
+pixi run refresh --dry-run --pr-body /tmp/body.md
+```
+
 Note for local runs: validation failures abort *after* the working tree was
 modified (in CI the commit is a separate gated step, so nothing is published) —
 recover with `git restore catalog collections.txt && git clean -fd catalog`.

--- a/docs/check-consistency.md
+++ b/docs/check-consistency.md
@@ -1,0 +1,188 @@
+# Catalog consistency checking
+
+Status: **reconciled against `scripts/refresh_catalog.py`** (as checked out at `639248ce9`).
+
+Originally a standalone proposal for [#11](https://github.com/uw-cryo/stac-3dep-1m/issues/11) / [#6](https://github.com/uw-cryo/stac-3dep-1m/issues/6).
+`refresh_catalog.py` now implements the detection core, so this document keeps only (a) where the two
+approaches differ, (b) what neither covers yet, and (c) the attribution question — *why* did a thing change.
+
+## Approach: where we agree
+
+Both landed on the same core, independently, and it is the right one: **paginated `ListObjectsV2` per project
+prefix, diffed against the local catalog** — no per-tile HEAD sweep, no sampling. Measured: 946 project
+prefixes in 6.4 s at 32 threads. Sampling one tile per collection would have missed `UT_WestEast_B22`
+(75 of 760 tiles gone; a sampled tile has ~90% odds of being alive).
+
+`refresh_catalog.py` also goes past what I had planned, in ways worth keeping:
+
+- **It remediates, not just detects.** My plan deliberately stopped at a report. Guardrails
+  (`--min-projects`, `--max-removed-tiles`), post-rebuild HEAD gates, and the unbiased existing-URL sample are
+  all things a detect-only design would have had to grow anyway.
+- **The `carried_empty` restage logic is a better answer than my open question.** I had "delete or flag?"
+  unresolved; the never-prune-on-inconclusive-probe rule is the right default given #6 caught the bucket
+  mid-repopulation.
+- **Both pagination bugs are fixed** — `create_static_stac.py:296` and `create_all.py:13`. Those were real:
+  `OR_SouthEast_D22` was the only collection sitting at exactly 1000 items (1165 on S3), and the project
+  listing was at 959 against the 1000 cap.
+
+## Approach: where they differ
+
+1. **Item identity comes from the filename stem, not the asset href.** `catalog_state()` keys off `p.stem`;
+   `item_asset_url()` is only consulted for probes. I had argued for parsing `assets.elevation.href` because
+   that is the field that actually breaks downstream. Verified equivalent on a 1,500-item sample, and cheap
+   either way (~35 s to parse all 123,659) — but as written, an item whose href is wrong while its filename is
+   right is invisible. Low severity, easy to tighten.
+
+2. **No internal-consistency check.** Items listed in `collection.json` but absent on disk (or vice versa),
+   collections missing from root `catalog.json`, hrefs pointing at the wrong collection. This is the free,
+   no-network half of the check, and it catches *our* bugs rather than USGS's. `refresh_catalog.py` maintains
+   these invariants when it runs, but nothing verifies them.
+
+3. **Diff granularity is the tile set only.** Which is correct for existence — and is exactly why the two gaps
+   below are invisible to it.
+
+## Gap 1: content drift (tile reprocessed in place)
+
+Same key, new pixels — no add, no remove, so a set diff cannot see it. Arguably the worst failure mode, since
+sampling silently returns stale elevations with no error anywhere.
+
+The listing already returns `Size` and `ETag` for free; neither script records them. `LastModified` alone is
+useless here — every tile in `WA_KingCounty_2021_B21` reads `2026-02-14`, which is the bulk prefix rewrite
+noted in #6, not per-tile reprocessing.
+
+Fix: add `file:size` + `file:checksum` to each asset at creation time (STAC `file` extension), so the catalog
+carries its own drift baseline and downstream consumers can tell whether their copy is current. Backfill is
+123k items. Alternative — a sidecar `checkpoints/s3-manifest.parquet` diffed run over run — is cheaper but
+adds a second source of truth.
+
+## Gap 2: WESM metadata drift
+
+**This is the one that matters most and is currently unhandled.** `refresh_catalog.py` rebuilds a project only
+when its *tile set* changes. Collection summaries carry `wesm:*` snapshotted at build time, and every item's
+`start_datetime`/`end_datetime` derives from WESM `collect_start`/`collect_end` — the exact field SlideRule's
+AMS table keys on. If USGS revises WESM without touching the tiles, the catalog keeps the stale values
+indefinitely.
+
+Measured today, 946 collections vs live `WESM.csv`:
+
+| Field | Collections drifted |
+| --- | --- |
+| `sourcedem_update` | 28 |
+| `lpc_update` | 17 |
+| `onemeter_category` | 15 |
+| `collect_start` | 1 (`NV_USFSR4_D23`) |
+| `spec`, `lpc_pub_date`, `sourcedem_pub_date` | 1 each |
+| workunit no longer in WESM at all | 1 (`UT_StrawberryRiver_2019`) |
+
+Small, but not zero, and `collect_start` drift is a silent wrong answer rather than a missing one. Proposed:
+extend the diff to include a WESM-summary comparison, and treat a WESM change as a rebuild trigger (or at
+minimum a collection-metadata refresh, which is far cheaper than re-running titiler over every tile).
+
+## Attributing *why* something changed
+
+The `--dry-run` output says *what* moved, never *why*. That gap is real, but it is largely fillable — just not
+from the field you would first reach for.
+
+**WESM's `*_reason` fields do not explain removals.** They describe spec compliance, not staging status. Every
+one of the vanished `UT_FemaHQ_*` workunits still reads `onemeter_category = Meets`,
+`onemeter_reason = "Meets 3DEP 1-m DEM requirements"` while its TIFFs are gone. Taking `_reason` at face value
+would actively mislead.
+
+Four signals that *do* attribute, in descending order of confidence:
+
+**1. Withdrawn for cause — `onemeter_category` transition.** Affirmative and machine-readable.
+`LA_BretonIslandTB_D24` went `Meets` → `Does not meet` (`"LPC does not meet"`) and is one of the 11 dead
+collections. The source point cloud failed QA, so USGS pulled the 1 m product. This explains 1 of 11.
+(The other 14 category changes all move *toward* validity — `Pending publication` → `Meets` — which is a
+publication event, not a withdrawal.)
+
+**2. Renamed / consolidated — grid-cell overlap against current holdings.** Not in WESM at all; derivable only
+by comparing `xNNyNNN` cells to what is staged now. USGS is collapsing workunit-level folders into
+project-level ones:
+
+| Dead collection | Replacement | Cells recovered |
+| --- | --- | --- |
+| `AZ_BrawleyRillito_FEMA_2018` | `AZ_BrawleyRillito_2018_D19` | 80/80 |
+| `UT_FEMAHQ_B2_2018` | `UT_FEMAHQ_2018_D18` | 48/48 |
+| `NV_LasVegas_QL2_2016` | `NV_Las_Vegas_Region_2016_A16` | 51/51 |
+| `UT_FemaHQ_B1_TL_2018` | `UT_FEMAHQ_2018_D18` (partial) | 22/85 |
+| `NM_SantaFeCo_2014` | several newer `NM_*` | 54/90 |
+
+Strongly correlated with a naming-convention migration: **8 of the 11 dead collections are 100 %
+legacy-named** (`USGS_one_meter_*`, no UTM-zone token) against a 27.6 % catalog-wide baseline. USGS appears to
+be restaging legacy products under the modern `USGS_1M_<zone>_*` convention and deleting the old files.
+Note this also breaks naive tile-id comparison across collections — the legacy names carry no zone, so any
+cell-overlap logic has to parse both conventions.
+
+**3. TIFFs missing from an otherwise intact product folder — companion-file count.** Derived purely from the
+S3 listing already performed; **do not use WESM for this** (see the caveat below). Where the project folder
+survives, compare the surviving `browse/` and `metadata/` companion counts to our item count:
+
+| Collection | Catalog items | Remnants | All rewritten |
+| --- | --- | --- | --- |
+| `NM_SantaFeCo_2014` | 90 | 90 browse + 90 metadata (+ `test_temp.gmc`) | 2026-05-21 |
+| `NV_LasVegas_QL1_2016` | 30 | 30 browse + 30 metadata | 2026-02-14 |
+| `NV_LasVegas_QL2_2016` | 51 | 51 browse + 51 metadata | 2026-02-14 |
+| `LA_BretonIslandTB_D24` | 5 | none (one stray `.vrt`) | 2026-05-14 |
+
+A one-to-one thumbnail and XML for every missing TIFF, all stamped with a single rewrite date, means the whole
+folder was re-staged and only the TIFF payload failed to land. The one collection WESM *does* explain
+(`LA_BretonIslandTB_D24`, withdrawn for cause) is also the one with no companions left — a clean withdrawal.
+So the signal discriminates.
+
+It does **not** establish that a rebuild is in flight: the two `NV_LasVegas_*` folders were rewritten on
+2026-02-14 — the same mass re-staging event behind #6 — and six months later the TIFFs still have not
+returned. Label these `tiffs-missing-from-intact-folder`, not "restaging".
+
+**Caveat on WESM `*_update` dates — do not use them for this.** I originally read
+`NM_SantaFeCo_2014`'s `sourcedem_update`/`lpc_update` moving to `2026/05/15` as "the source data was revised,
+so the 1 m product is being regenerated". That does not survive checking the data dictionary:
+
+- Both fields describe the **LPC and OPR source-DEM products, not the 1 m derivative**. WESM has no
+  `onemeter_update` or `onemeter_pub_date` field at all — it carries *no* attribute describing 1 m staging
+  status.
+- `sourcedem_update` is defined as "The date an update was made to either the storage path **or** one or more
+  source DEM data files" — a path move alone bumps it, which is exactly what a bulk re-stage does.
+- `onemeter_category = "Meets"` means "Project/WU meets 3DEP specification(s) for the product type" —
+  **spec compliance, not availability**. It does not assert that a 1 m product is staged.
+
+The per-tile XMLs left behind are also unchanged in content (`pubdate 20200330`, `procdate 20190425`), so
+nothing was actually revised — the files were re-uploaded.
+
+Bottom line for `NM_SantaFeCo_2014`: **WESM cannot tell us whether it was erroneously added or deliberately
+removed** — it has no field that speaks to 1 m staging. The available evidence is circumstantial and points to
+an incomplete re-stage rather than a withdrawal, but it does not rule out a delisting that left companion
+files behind. The `--dry-run` verdict `treating as removed` is therefore *unproven*, not demonstrably wrong.
+
+**4. Workunit retired from WESM.** `UT_StrawberryRiver_2019` is simply gone from `WESM.csv` — unambiguous.
+
+**Residual: genuinely unexplained.** `UT_FemaHQ_B1_TL_2018` (63 of 85 cells with no replacement) and
+`UT_WestEast_B22`'s 75 vanished tiles show no WESM change, still `Meets`, no consolidating project. These are
+the cases worth raising with USGS rather than silently pruning — and they line up with #11's "0.9 % of the AOI
+is covered only by dead URLs".
+
+### Proposal
+
+Add an `--explain` pass that annotates each removal with one of `withdrawn-for-cause`, `superseded-by:<project>`,
+`tiffs-missing-from-intact-folder`, `retired-from-wesm`, `unexplained`, using signals 1–4. Cheap — WESM is one
+CSV already fetched per build, and both the cell index and the companion counts fall out of the S3 listing
+already performed. Feed it into the PR body so a reviewer sees *why*, and gate pruning on it: never auto-prune
+`tiffs-missing-from-intact-folder` or `unexplained`.
+
+Note the labels are evidence classes, not statements of USGS intent — only `withdrawn-for-cause` and
+`retired-from-wesm` rest on an affirmative USGS assertion.
+
+## Open questions
+
+1. **Should `tiffs-missing-from-intact-folder` and `unexplained` removals be pruned at all?** Current policy
+   prunes both once probes 404. `NM_SantaFeCo_2014` would be pruned today; if USGS is mid-restage it would
+   have to be rebuilt later, but the `NV_LasVegas_*` pair has sat in that state for six months, so waiting
+   indefinitely is not obviously better. Worth asking USGS directly rather than inferring — there is no
+   metadata field that answers it.
+2. **Deleted or deprecated?** Still open. Deleting is what #11 asks for and is safest for consumers; a
+   `superseded`-link approach preserves the record but pushes filtering onto every consumer.
+3. **Which artifact is checked — `catalog/` or the release parquet?** `main` runs ahead of the tag that
+   SlideRule's AMS table is built from, so "the repo is right" and "what people use is right" are different
+   questions.
+4. **Does WESM drift trigger a full titiler rebuild, or a metadata-only collection refresh?** The latter is
+   orders of magnitude cheaper and covers all 28 drifted collections.

--- a/scripts/refresh_catalog.py
+++ b/scripts/refresh_catalog.py
@@ -19,13 +19,15 @@ Designed to run unattended (scheduled CI) but equally usable locally:
      - every new/changed item URL sampled up to --sample-new must return 200
      - a random sample (--sample-existing) of carried-over item URLs must
        404 at a rate below --max-404-pct
-5. Write a machine-readable summary (--summary) plus GitHub Actions outputs
-   (changed / changelog / counts) when GITHUB_OUTPUT is set.
+5. Write a machine-readable summary (--summary), a markdown PR body with a
+   per-collection table (--pr-body), plus GitHub Actions outputs (changed /
+   title / subject / changelog / counts) when GITHUB_OUTPUT is set.
 
 Exit codes: 0 = success (changed or no-op), 1 = guardrail/validation failure.
 
 Usage:
   python scripts/refresh_catalog.py --dry-run          # report the diff only
+  python scripts/refresh_catalog.py --dry-run --pr-body /tmp/body.md
   python scripts/refresh_catalog.py --summary refresh_summary.json
 """
 
@@ -183,6 +185,94 @@ def head_check(urls, label, threads=8):
 
 
 # ------------------------------------------------------------------ summary
+# GitHub rejects a pull request body over 65536 characters, so long tables are
+# capped well short of that and the remainder left to the run summary.
+PR_BODY_MAX_ROWS = 150
+
+
+def _table(rows, headers):
+    out = ["| " + " | ".join(headers) + " |",
+           "| " + " | ".join(["---"] + ["---:"] * (len(headers) - 1)) + " |"]
+    for r in rows[:PR_BODY_MAX_ROWS]:
+        out.append("| " + " | ".join(str(c) for c in r) + " |")
+    if len(rows) > PR_BODY_MAX_ROWS:
+        out.append(f"| _… and {len(rows) - PR_BODY_MAX_ROWS} more_ | | |")
+    return "\n".join(out)
+
+
+def _section(title, rows, headers, collapse_over=25):
+    """A heading plus table, collapsed behind <details> when it gets long."""
+    if not rows:
+        return ""
+    body = _table(rows, headers)
+    if len(rows) > collapse_over:
+        return (f"<details>\n<summary><b>{title}</b> (click to expand)</summary>\n\n"
+                f"{body}\n\n</details>\n")
+    return f"#### {title}\n\n{body}\n"
+
+
+def render_pr_body(summary, run_url=None):
+    """Markdown PR body: headline counts plus a per-collection table."""
+    details = summary["details"]
+    failures = set(summary.get("build_failures") or [])
+
+    def rows(action, cols):
+        return [cols(p, d) for p, d in sorted(details.items())
+                if d["action"] == action]
+
+    new = rows("new", lambda p, d: (f"`{p}`", f"+{d['added']}"))
+    rebuilt = rows("rebuilt", lambda p, d: (
+        f"`{p}`", f"+{d['added']}" if d["added"] else "—",
+        f"−{d['removed']}" if d["removed"] else "—"))
+    pruned = rows("pruned", lambda p, d: (f"`{p}`", f"−{d['removed']}"))
+
+    added, removed = summary["tiles_added"], summary["tiles_removed"]
+    before = summary["catalog_items_before"]
+    after = summary.get("catalog_items_after")
+
+    out = [
+        "Automated run of `pixi run refresh` — S3 diff, incremental rebuild, "
+        "prune, HEAD validation (see `scripts/refresh_catalog.py`).",
+        "",
+        f"**+{added:,} / −{removed:,} tiles** across {len(details):,} collections "
+        f"— {len(new)} new, {len(rebuilt)} rebuilt, {len(pruned)} pruned.",
+        "",
+        f"Catalog items: {before:,}" + (f" → **{after:,}**" if after else ""),
+        "",
+    ]
+    out.append(_section("New collections", new, ["Collection", "Tiles"]))
+    out.append(_section("Rebuilt collections", rebuilt,
+                        ["Collection", "Added", "Removed"]))
+    out.append(_section("Pruned collections", pruned, ["Collection", "Tiles"]))
+
+    if summary.get("carried_empty_projects"):
+        names = ", ".join(f"`{p}`" for p in summary["carried_empty_projects"])
+        out.append(f"> **Carried, not pruned:** {names} — TIFF listing empty but the "
+                   "removal probe was inconclusive; re-probed next run.\n")
+    if failures:
+        names = ", ".join(f"`{p}`" for p in sorted(failures))
+        out.append(f"> **⚠️ Build failures:** {names} — previous version kept. Usually a "
+                   "WESM name mismatch (see `onemeter_folder_to_wesm` in "
+                   "`scripts/create_static_stac.py`).\n")
+
+    if run_url:
+        out.append(f"Full diff summary in the [workflow run]({run_url}).")
+    out.append("After merging, `release.yml` (monthly cron, or manual "
+               "workflow_dispatch) rebuilds `catalog.parquet`/`catalog.gti` and "
+               "publishes a dated release.")
+    return "\n".join(out).replace("\n\n\n", "\n\n") + "\n"
+
+
+def run_url():
+    """URL of the running workflow job, or None outside Actions."""
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if server and repo and run_id:
+        return f"{server}/{repo}/actions/runs/{run_id}"
+    return None
+
+
 def github_output(**kwargs):
     out = os.environ.get("GITHUB_OUTPUT")
     if not out:
@@ -224,6 +314,9 @@ def main():
                     help="S3 listing / HEAD check concurrency")
     ap.add_argument("--summary", type=Path, default=None,
                     help="write a JSON run summary to this path")
+    ap.add_argument("--pr-body", type=Path, default=None,
+                    help="write the rendered markdown PR body to this path "
+                         "(also written on --dry-run, for local preview)")
     args = ap.parse_args()
 
     if not CATALOG_DIR.is_dir():
@@ -275,10 +368,20 @@ def main():
                   f"(HEAD codes {codes}) -- carrying unchanged, will re-probe "
                   "next run", flush=True)
 
-    n_tiles_added = (sum(len(holdings[p]) for p in new)
-                     + sum(len(set(holdings[p]) - local[p]) for p in changed))
-    n_tiles_removed = (sum(len(local[p]) for p in removed)
-                       + sum(len(local[p] - set(holdings[p])) for p in changed))
+    # Per-project tile deltas, computed once and reused by the console log, the
+    # summary JSON and the PR body table.
+    details = {}
+    for p in new:
+        details[p] = {"action": "new", "added": len(holdings[p]), "removed": 0}
+    for p in changed:
+        details[p] = {"action": "rebuilt",
+                      "added": len(set(holdings[p]) - local[p]),
+                      "removed": len(local[p] - set(holdings[p]))}
+    for p in removed:
+        details[p] = {"action": "pruned", "added": 0, "removed": len(local[p])}
+
+    n_tiles_added = sum(d["added"] for d in details.values())
+    n_tiles_removed = sum(d["removed"] for d in details.values())
     n_local = sum(len(v) for v in local.values())
     n_s3 = sum(len(v) for v in holdings.values())
 
@@ -286,12 +389,11 @@ def main():
     print(f"diff: +{n_tiles_added} tiles / -{n_tiles_removed} tiles  "
           f"({len(new)} new, {len(changed)} changed, {len(removed)} removed projects)")
     for p in new:
-        print(f"  NEW      {p} ({len(holdings[p])} tiles)")
+        print(f"  NEW      {p} ({details[p]['added']} tiles)")
     for p in changed:
-        print(f"  CHANGED  {p} (+{len(set(holdings[p]) - local[p])} / "
-              f"-{len(local[p] - set(holdings[p]))})")
+        print(f"  CHANGED  {p} (+{details[p]['added']} / -{details[p]['removed']})")
     for p in removed:
-        print(f"  REMOVED  {p} ({len(local[p])} tiles)")
+        print(f"  REMOVED  {p} ({details[p]['removed']} tiles)")
 
     changed_any = bool(new or changed or removed)
     summary = {
@@ -300,8 +402,10 @@ def main():
         "new_projects": new, "changed_projects": changed, "removed_projects": removed,
         "carried_empty_projects": carried_empty,
         "tiles_added": n_tiles_added, "tiles_removed": n_tiles_removed,
-        "dry_run": args.dry_run, "build_failures": [],
+        "dry_run": args.dry_run, "build_failures": [], "details": details,
     }
+    # "+1429/-678 tiles" -- short enough for a PR/commit title on its own
+    title = f"+{n_tiles_added}/-{n_tiles_removed} tiles"
 
     if not changed_any:
         print("no changes -- catalog is current")
@@ -319,10 +423,13 @@ def main():
 
     if args.dry_run:
         print("dry run -- exiting before rebuild")
-        github_output(changed="false", changelog="dry run")
+        github_output(changed="false", changelog="dry run", title=title)
         if args.summary:
             summary["elapsed_s"] = round(time.time() - t0, 1)
             args.summary.write_text(json.dumps(summary, indent=1))
+        if args.pr_body:
+            args.pr_body.write_text(render_pr_body(summary, run_url()))
+            print(f"PR body preview written to {args.pr_body}")
         return
 
     # ------------------------------------------------------------- rebuild
@@ -406,8 +513,14 @@ def main():
     })
     if args.summary:
         args.summary.write_text(json.dumps(summary, indent=1))
-    github_output(changed="true", changelog=changelog,
-                  n_items=n_after, n_failures=len(failures))
+    if args.pr_body:
+        args.pr_body.write_text(render_pr_body(summary, run_url()))
+    # `title` and `subject` stay short enough to read in a PR list / git log;
+    # the exhaustive project list lives in the PR body table and the summary JSON
+    subject = (f"{title} ({len(new)} new, {len(changed)} rebuilt, "
+               f"{len(removed)} pruned)")
+    github_output(changed="true", changelog=changelog, title=title,
+                  subject=subject, n_items=n_after, n_failures=len(failures))
     print(f"\nrefresh complete in {summary['elapsed_s']}s: {changelog}")
     print(f"catalog items: {n_local} -> {n_after}")
 


### PR DESCRIPTION
Follow-up to #13. The refresh PR title currently embeds the whole changelog, so #15 came out as ~500 characters of comma-separated project names truncated mid-word, with the same blob repeated in the body inside a code fence.

### Changes

- **Short title.** New `title` output (`+1429/-678 tiles`) drives the PR title, so #15 would have read **"Update catalog (+1429/-678 tiles)"**. A `subject` output adds the counts for the commit message.
- **Table body.** `refresh_catalog.py --pr-body PATH` renders headline counts plus per-collection tables of added/removed tiles, grouped new/rebuilt/pruned. The workflow passes it with `body-path`, which takes precedence over `body` in create-pull-request v8.
- Per-project deltas are now computed once into a `details` map reused by the console log, the summary JSON (new `details` key) and the body — no recomputation, and the JSON gains per-collection numbers it did not have.
- Carried-not-pruned projects and build failures render as callouts, so soft failures like `UT_StrawberryRiver_2019` are visible in the PR rather than only in the run log.
- Long tables collapse behind `<details>` and cap at 150 rows (GitHub rejects a body over 65536 characters).

### Verification

Live dry run against current S3 holdings — 88 collections render to 4.3 kB, and `title` comes out `+1429/-678 tiles`. Preview locally without touching the catalog:

```
pixi run refresh --dry-run --pr-body /tmp/body.md
```

<details>
<summary>Rendered body for the #15 diff (click to expand)</summary>

> Automated run of `pixi run refresh` — S3 diff, incremental rebuild, prune, HEAD validation (see `scripts/refresh_catalog.py`).
> 
> **+1,429 / −678 tiles** across 88 collections — 0 new, 77 rebuilt, 11 pruned.
> 
> Catalog items: 123,659
> 
> <details>
> <summary><b>Rebuilt collections</b> (click to expand)</summary>
> 
> | Collection | Added | Removed |
> | --- | ---: | ---: |
> | `AZ_AubreyCherry_2020_D20` | — | −5 |
> | `AZ_BlackRock_Goodwin_2021_D21` | — | −4 |
> | `AZ_CORiverBasin_L1_2014` | +1 | — |
> | `AZ_CentralCoconino_B22` | +13 | — |
> | `AZ_ColoradoRiverLot2_2014` | +1 | — |
> | `AZ_Eastern_D24` | +31 | — |
> | `AZ_GrandCanyonNP_2019_B19` | +4 | −2 |
> | `AZ_LowerColoradoRiver_2015` | +1 | — |
> | `AZ_LowerColoradoRiver_2018_B18` | — | −1 |
> | `AZ_MohaveCoconino_D23` | — | −21 |
> | `AZ_NorthEast_D23` | — | −37 |
> | `AZ_PimaCounty_2021_B21` | +69 | — |
> | `AZ_SouthWest_D23` | +16 | — |
> | `CA_LakeCounty_C16` | +2 | — |
> | `CA_LosAngeles_B23` | +13 | — |
> | `CA_NoCAL_3DEP_Supp_Funding_2018_D18` | +77 | — |
> | `CA_NoCAL_Wildfires_B2_2018` | +1 | — |
> | `CA_NorthCoastRanges_B23` | +5 | — |
> | `CA_SaltonSea_EarthMRI_2021_D21` | +15 | — |
> | `CA_SanDiego_2015_C17_1` | +8 | — |
> | `CA_SierraNevada_B22` | +7 | — |
> | `CA_Yurok_T23` | +21 | — |
> | `KS_Statewide_2018_A18` | +16 | — |
> | `LA_NortheastDOTD_2017_C20` | +2 | — |
> | `ME_EasternME_2017_A17` | +27 | — |
> | `ME_Eastern_B1_2017` | +5 | — |
> | `ME_Eastern_B2_2017` | +25 | — |
> | `ME_MidCentral_B23` | +12 | — |
> | `ME_Umbagog_2016` | +1 | — |
> | `ME_Western_ME_LiDAR_2016_B16` | +2 | — |
> | `MI_31County_2016_A16` | +59 | — |
> | `MI_Hiawatha_NF_2018_D18` | +2 | — |
> | `MN_CentralMissRiver_B22` | +11 | — |
> | `MN_RainyLake_2020_B20` | +27 | — |
> | `MN_UpperMissRiver_B22` | +57 | — |
> | `MO_Northern_SEMO_2021_D21` | +3 | — |
> | `MS_Central_Delta_2018_D18` | +3 | — |
> | `MS_Laurel_2014` | +17 | — |
> | `MS_NRCS_East_2018_B19` | +5 | — |
> | `MS_Tupelo_UTM16_2015` | +3 | — |
> | `MT_HighlineCompletionWibaux_2021_D21` | +19 | — |
> | `MT_Statewide_Phase2_2020_B20` | +79 | — |
> | `MT_Statewide_Phase4_B22` | +12 | — |
> | `Maine_and_Massachusetts_QL1_and_QL2_LiDAR_BAA` | +64 | — |
> | `ND_3DEPProcessing_D22` | +30 | — |
> | `ND_Lidar_Phase10` | +38 | — |
> | `NE_Hat_White_Cherry_UTM14_2016` | +18 | — |
> | `NE_Statewide_D23` | +16 | — |
> | `NH_Umbagog_LiDAR_2016_D16` | +4 | — |
> | `NM_MRCOG_2018_C20` | +39 | — |
> | `NM_North_Central_FEMA_R6_Lidar_2016_D17` | +11 | — |
> | `NM_Rio_San_Jose_FEMA_R6_Lidar_2016_D17` | +96 | — |
> | `NM_SouthCentral_2018_D19` | +14 | — |
> | `NV_Humboldt_2021_D21` | +4 | — |
> | `NV_USFSR4_D23` | — | −3 |
> | `NV_WestCentral_EarthMRI_2020_D20` | +28 | — |
> | `OR_SouthEast_D22` | +165 | — |
> | `SD_FY17_NRCS_Lidar_QSI_2017_D17` | +114 | — |
> | `SD_MORiver_Woolpert_B2_2016` | +1 | — |
> | `SD_MORiver_Woolpert_B3_2016` | +2 | — |
> | `TN_NRCS_L1_2011_12` | +1 | — |
> | `TN_WestTN_2019_B19` | +1 | — |
> | `TX_WestTexas_2018_D19` | +22 | — |
> | `UT_FEMA_FS_FlamingGorge_2020_B20` | — | −6 |
> | `UT_StatewideCenSouth_2020_A20` | — | −10 |
> | `UT_StatewideNCentral_2020_A20` | — | −1 |
> | `UT_StrawberryRiver_2019` | — | −6 |
> | `UT_WestEast_B22` | — | −75 |
> | `WA_CentralWildfire_D22` | +23 | — |
> | `WA_Mount_Adams_LiDAR_2016_D16` | +13 | — |
> | `WA_NorthEast_B22` | +10 | — |
> | `WA_Olympic_Peninsula_1A_2017` | +2 | — |
> | `WA_Olympic_Peninsula_Lidar_2017_B17` | +2 | — |
> | `WI_12County_B22` | +16 | — |
> | `WI_AshlandIronFlorence_2019_D19` | +18 | — |
> | `WI_Bayfield_2016` | +3 | — |
> | `WI_Washburn_2016` | +2 | — |
> 
> </details>
> 
> #### Pruned collections
> 
> | Collection | Tiles |
> | --- | ---: |
> | `AZ_BrawleyRillito_FEMA_2018` | −80 |
> | `AZ_BrawleyRillito_NRCS_2018` | −39 |
> | `LA_BretonIslandTB_D24` | −5 |
> | `NM_SantaFeCo_2014` | −90 |
> | `NV_LasVegas_QL1_2016` | −30 |
> | `NV_LasVegas_QL2_2016` | −51 |
> | `UT_FEMAHQ_B1_2018` | −15 |
> | `UT_FEMAHQ_B2_2018` | −48 |
> | `UT_FEMAHQ_B2_QL1_2018` | −19 |
> | `UT_FemaHQ_B1_TL_2018` | −85 |
> | `UT_FemaHQ_B2_TL_2018` | −45 |
> 
> Full diff summary in the [workflow run](https://github.com/uw-cryo/stac-3dep-1m/actions/runs/31433705738).
> After merging, `release.yml` (monthly cron, or manual workflow_dispatch) rebuilds `catalog.parquet`/`catalog.gti` and publishes a dated release.

</details>
