### PR TITLE
Refresh WESM metadata when the tile set is unchanged

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -3,7 +3,8 @@
 # Extends the original create-all-based version of this workflow: in addition
 # to building STAC for new project folders, scripts/refresh_catalog.py also
 # rebuilds projects whose tile set drifted (tiles added/removed in place,
-# restaged data), prunes projects deleted upstream, and validates with
+# restaged data), prunes projects deleted upstream, refreshes collections whose
+# WESM metadata was revised without touching tiles, and validates with
 # guardrails + HTTP HEAD spot checks before the PR is opened (see the script
 # docstring). Release assets are cut by release.yml (monthly cron or manual
 # dispatch, skipping when the catalog is unchanged since the latest release).
@@ -21,6 +22,10 @@ on:
         default: false
       allow_large_removals:
         description: "Override the max-removed-tiles guardrail (after reviewing a dry run)"
+        type: boolean
+        default: false
+      allow_large_metadata_updates:
+        description: "Override the max-metadata-updates guardrail (after reviewing a dry run)"
         type: boolean
         default: false
 
@@ -57,6 +62,9 @@ jobs:
           fi
           if [ "${{ inputs.allow_large_removals }}" = "true" ]; then
             ARGS="$ARGS --allow-large-removals"
+          fi
+          if [ "${{ inputs.allow_large_metadata_updates }}" = "true" ]; then
+            ARGS="$ARGS --allow-large-metadata-updates"
           fi
           pixi run refresh $ARGS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ Some folders have no TIFFs at all; those are listed in `NO_TIFFS` in `create_all
 * abort if the diff would remove > `--max-removed-tiles` (2000) tiles, unless `--allow-large-removals`;
 * a cataloged project whose `TIFF/` went empty is pruned **only** if the folder prefix is gone, or every probed item URL returns 404 — a 200, a probe error, or nothing to probe means carry unchanged and re-decide next run. Never make pruning fire on network errors.
 * new/changed item URLs must all HEAD 200; a random sample of *untouched* carried-over items must 404 below `--max-404-pct`.
+* abort if more than `--max-metadata-updates` (300) collections drift in WESM, unless `--allow-large-metadata-updates` — a WESM schema change (column added/renamed) drifts every collection at once.
+
+A tile-set diff cannot see a WESM revision that adds or removes no tiles (issue #18), so `refresh` also compares each `collection.json`'s snapshotted `wesm:*` summaries against live `WESM.csv` and repairs the drifted ones **in place** — summaries, collection temporal extent, and (only when `collect_start`/`collect_end` moved) every item's `start_datetime`/`end_datetime`. No titiler round trip; the tiles are untouched. Both sides of the comparison go through `create_static_stac.wesm_summary_fields()` so a serialization difference cannot masquerade as drift, and the rewrite is byte-identical to a full rebuild apart from those fields. A collection whose folder name no longer resolves in WESM is reported, never modified. Disable with `--skip-wesm-check`.
 
 Tiles removed in place also need their item JSONs unlinked explicitly after a rebuild, otherwise the same projects are flagged changed every run and the parquet row-count gate diverges.
 

--- a/docs/check-consistency.md
+++ b/docs/check-consistency.md
@@ -55,28 +55,40 @@ carries its own drift baseline and downstream consumers can tell whether their c
 123k items. Alternative — a sidecar `checkpoints/s3-manifest.parquet` diffed run over run — is cheaper but
 adds a second source of truth.
 
-## Gap 2: WESM metadata drift
+## Gap 2: WESM metadata drift — **closed** ([#18](https://github.com/uw-cryo/stac-3dep-1m/issues/18))
 
-**This is the one that matters most and is currently unhandled.** `refresh_catalog.py` rebuilds a project only
-when its *tile set* changes. Collection summaries carry `wesm:*` snapshotted at build time, and every item's
-`start_datetime`/`end_datetime` derives from WESM `collect_start`/`collect_end` — the exact field SlideRule's
-AMS table keys on. If USGS revises WESM without touching the tiles, the catalog keeps the stale values
-indefinitely.
+`refresh_catalog.py` used to rebuild a project only when its *tile set* changed. Collection summaries carry
+`wesm:*` snapshotted at build time, and every item's `start_datetime`/`end_datetime` derives from WESM
+`collect_start`/`collect_end` — the exact field SlideRule's AMS table keys on. A WESM revision that touched no
+tiles therefore never reached the catalog.
 
-Measured today, 946 collections vs live `WESM.csv`:
+`refresh` now diffs the snapshotted summaries against live `WESM.csv` on every run and repairs the drifted
+collections **in place** (`wesm_diff` / `refresh_collection_metadata`): summaries, collection temporal extent,
+and item datetimes only when the collect range itself moved. No titiler round trip — the answer to open
+question 4 below is *metadata-only refresh*, and the guardrail is `--max-metadata-updates` (300) since a WESM
+schema change would drift every collection at once.
+
+The backlog this cleared was larger than the original measurement suggested — 192 of 946 collections, because
+the drift includes not only USGS revisions but the `collapse_workunit_rows` fix (deterministic representative
+row, min/max collect range over multi-workunit projects) that collections built before it never picked up:
 
 | Field | Collections drifted |
 | --- | --- |
-| `sourcedem_update` | 28 |
-| `lpc_update` | 17 |
-| `onemeter_category` | 15 |
-| `collect_start` | 1 (`NV_USFSR4_D23`) |
-| `spec`, `lpc_pub_date`, `sourcedem_pub_date` | 1 each |
-| workunit no longer in WESM at all | 1 (`UT_StrawberryRiver_2019`) |
+| `workunit` / `workunit_id` | 115 |
+| `lpc_pub_date` | 108 |
+| `sourcedem_pub_date` | 106 |
+| `collect_end` | 105 |
+| `horiz_crs` | 44 |
+| `sourcedem_update` | 33 |
+| `dem_gsd_meters` | 30 |
+| `lpc_update` | 22 |
+| `ql` | 19 |
+| `*_category` / `*_reason` | 13–14 each |
+| `spec`, `vert_crs`, `geoid`, `p_method` | 3–8 each |
 
-Small, but not zero, and `collect_start` drift is a silent wrong answer rather than a missing one. Proposed:
-extend the diff to include a WESM-summary comparison, and treat a WESM change as a rebuild trigger (or at
-minimum a collection-metadata refresh, which is far cheaper than re-running titiler over every tile).
+105 of those moved a collect range, i.e. ~39k item files whose `start_datetime`/`end_datetime` were wrong.
+No cataloged collection is currently unresolvable in WESM (`UT_StrawberryRiver_2019` resolves again); when one
+is, it is reported and left untouched rather than guessed at.
 
 ## Attributing *why* something changed
 
@@ -184,5 +196,5 @@ Note the labels are evidence classes, not statements of USGS intent — only `wi
 3. **Which artifact is checked — `catalog/` or the release parquet?** `main` runs ahead of the tag that
    SlideRule's AMS table is built from, so "the repo is right" and "what people use is right" are different
    questions.
-4. **Does WESM drift trigger a full titiler rebuild, or a metadata-only collection refresh?** The latter is
-   orders of magnitude cheaper and covers all 28 drifted collections.
+4. ~~**Does WESM drift trigger a full titiler rebuild, or a metadata-only collection refresh?**~~ Resolved:
+   metadata-only refresh, implemented in `refresh_catalog.py` (see Gap 2 above).

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,7 @@ create-all = { cmd = "python scripts/create_all.py", description = "Create stati
 create-stac = { cmd = "python scripts/create_static_stac.py", description = "Create a static STAC catalog+collection for a single project or WESM workunit" }
 collection2geoparquet = { cmd = "python scripts/collection2geoparquet.py", description = "Convert one collection.json and its items to a STAC-GeoParquet file" }
 catalog2geoparquet = { cmd = "python scripts/catalog2geoparquet.py catalog/catalog.json catalog.parquet", description = "Convert the full root catalog to a single STAC-GeoParquet file" }
-refresh = { cmd = "python scripts/refresh_catalog.py", description = "Diff catalog/ against current S3 holdings; rebuild new/changed projects, prune deleted ones, validate" }
+refresh = { cmd = "python scripts/refresh_catalog.py", description = "Diff catalog/ against current S3 holdings and WESM; rebuild new/changed projects, prune deleted ones, refresh drifted metadata, validate" }
 catalog2hive = { cmd = "python scripts/catalog2hive.py", description = "Write the catalog as hive-partitioned STAC-GeoParquet (collection=<id>/part0.parquet)" }
 create-collection-parquets = { cmd = "python scripts/create_collection_parquets.py", description = "Write a .parquet next to each collection.json under a catalog directory" }
 update-root-catalog = { cmd = "python scripts/update_root_catalog.py", description = "Add any new child collections to the top-level catalog.json" }

--- a/scripts/create_static_stac.py
+++ b/scripts/create_static_stac.py
@@ -105,15 +105,25 @@ def get_titiler_datetime(series):
 #     item.properties.update(series.add_prefix('wesm:').to_dict())
 
 
-def add_wesm_metadata_to_collection(collection, series):
-    """Add to extra_fields dictionary"""
+def wesm_summary_fields(series):
+    """The wesm:-prefixed collection summaries for one WESM row (JSON-safe).
+
+    Kept separate from add_wesm_metadata_to_collection so refresh_catalog.py can
+    compare a live WESM row field-for-field against the summaries snapshotted in
+    an existing collection.json (issue #18) -- both sides have to come out of the
+    same serialization to be comparable.
+    """
     links = ["lpc_link", "sourcedem_link", "metadata_link"]
     # Ensure JSON-serializable
-    wesm_properties = json.loads(series.drop(links).add_prefix("wesm:").to_json())
+    return json.loads(series.drop(links).add_prefix("wesm:").to_json())
+
+
+def add_wesm_metadata_to_collection(collection, series):
+    """Add to extra_fields dictionary"""
     # STAC-browser does not render this
     # collection.extra_fields = {'properties':wesm_properties}
     # WARNING: this creates *invalid* STAC, be default STAC-browser still renders it!
-    for k, v in wesm_properties.items():
+    for k, v in wesm_summary_fields(series).items():
         collection.summaries.add(k, v)
 
 
@@ -209,18 +219,35 @@ def collapse_workunit_rows(rows):
     return s
 
 
-def get_wesm_series(project, is_workunit=False):
+def load_wesm():
+    """The USGS WESM metadata table (locally cached by cloudpathlib)."""
     wesm_csv = client.CloudPath(
         "s3://prd-tnm/StagedProducts/Elevation/metadata/WESM.csv"
     )
-    df = pd.read_csv(wesm_csv)
+    return pd.read_csv(wesm_csv)
+
+
+def get_wesm_series(project, is_workunit=False, df=None, warn=True):
+    """Single collapsed WESM row for a project or workunit name.
+
+    Pass an already-loaded `df` to look up many names without re-reading the CSV,
+    and warn=False to look them up quietly (refresh_catalog.py checks all ~900
+    cataloged collections on every run).
+    """
+    if df is None:
+        df = load_wesm()
 
     # Fast track manually specified mappings
     if project in onemeter_folder_to_wesm:
         name = onemeter_folder_to_wesm[project]
         # NOTE: maybe issue here in cases of updated processing? check for source_dem update?
         #.e.g. TN_NRCS_L2_2011_12
-        s = collapse_workunit_rows(df[df.workunit == name])
+        rows = df[df.workunit == name]
+        if rows.empty:
+            raise ValueError(
+                f"Workunit '{name}' mapped from folder '{project}' not found in WESM metadata"
+            )
+        s = collapse_workunit_rows(rows)
     else:
         if is_workunit:
             if project not in df.workunit.values:
@@ -237,7 +264,7 @@ def get_wesm_series(project, is_workunit=False):
                 )
             s = collapse_workunit_rows(df[df.project == project])
 
-    if not s.onemeter_category == "Meets":
+    if warn and not s.onemeter_category == "Meets":
         warnings.warn(
             f"Project '{project}' onemeter_category is not 'Meets' but '{s.onemeter_category}'"
         )

--- a/scripts/refresh_catalog.py
+++ b/scripts/refresh_catalog.py
@@ -11,10 +11,14 @@ Designed to run unattended (scheduled CI) but equally usable locally:
      - changed projects    -> rebuild with create_static_stac.py --overwrite
        (tile added/removed within an existing project, e.g. restaged data)
      - removed projects    -> prune catalog/<project> and root catalog link
+     - WESM metadata drift -> metadata-only refresh of catalog/<project>
+       (collection summaries + temporal extent, item datetimes; no titiler)
 3. Guardrails (issue #6: the bucket has been observed mid-repopulation):
      - abort if S3 lists fewer than --min-projects project folders
      - abort if the diff would remove more than --max-removed-tiles tiles
        (override with --allow-large-removals after human review)
+     - abort if more than --max-metadata-updates collections drifted in WESM
+       (override with --allow-large-metadata-updates)
 4. Validate with HTTP HEAD spot checks:
      - every new/changed item URL sampled up to --sample-new must return 200
      - a random sample (--sample-existing) of carried-over item URLs must
@@ -46,6 +50,11 @@ import boto3
 import requests
 from botocore import UNSIGNED
 from botocore.client import Config
+
+# sibling script (scripts/ is on sys.path when this file is run directly), so the
+# refresh and the builder agree on how a folder name maps to a WESM row and how
+# that row is serialized into collection summaries
+import create_static_stac
 
 BUCKET = "prd-tnm"
 PROJECTS_PREFIX = "StagedProducts/Elevation/1m/Projects/"
@@ -117,6 +126,109 @@ def item_asset_url(project, item_id):
         return item["assets"]["elevation"]["href"]
     except Exception:
         return None
+
+
+# ------------------------------------------------------------ WESM metadata
+# A rebuild triggers on tile-set change, so a WESM revision that adds or removes
+# no tiles would otherwise never reach the catalog (issue #18): collection wesm:*
+# summaries are snapshotted at build time, and every item's start_datetime /
+# end_datetime derives from WESM collect_start / collect_end -- the field
+# SlideRule's AMS 3DEP1M table keys on (issue #11), where a stale value is a
+# wrong answer rather than a missing one.
+def wesm_row(project, df):
+    """Live WESM row for a cataloged folder name, or None if WESM has none.
+
+    Mirrors build_project: try the folder as a workunit first, then as a project
+    (the S3 folder name is sometimes one, sometimes the other, and sometimes
+    neither -- see onemeter_folder_to_wesm in create_static_stac.py).
+    """
+    for is_workunit in (True, False):
+        try:
+            return create_static_stac.get_wesm_series(project, is_workunit=is_workunit,
+                                                      df=df, warn=False)
+        except (ValueError, KeyError, IndexError):
+            continue
+    return None
+
+
+def collection_wesm_summaries(project):
+    """wesm:* summaries recorded in a collection.json (None if unreadable)."""
+    path = CATALOG_DIR / project / "collection.json"
+    try:
+        summaries = json.loads(path.read_text()).get("summaries", {})
+    except Exception:
+        return None
+    return {k: v for k, v in summaries.items() if k.startswith("wesm:")}
+
+
+def wesm_diff(projects):
+    """(drift, rows, missing) for the given cataloged projects.
+
+    drift    {project: [drifted summary field, ...]}
+    rows     {project: live WESM row} for the drifted projects
+    missing  [project, ...] cataloged but no longer resolvable in WESM
+
+    Both sides of the comparison are produced by wesm_summary_fields(), so a
+    serialization difference cannot masquerade as drift. `missing` is reported
+    but never acted on: WESM dropping a workunit says nothing about whether the
+    tiles are still staged (that is the S3 diff's job), so it is a human's call.
+    """
+    df = create_static_stac.load_wesm()
+    drift, rows, missing = {}, {}, []
+    for project in projects:
+        have = collection_wesm_summaries(project)
+        if have is None:
+            continue
+        series = wesm_row(project, df)
+        if series is None:
+            missing.append(project)
+            continue
+        want = create_static_stac.wesm_summary_fields(series)
+        fields = sorted(k for k in set(have) | set(want) if have.get(k) != want.get(k))
+        if fields:
+            drift[project] = fields
+            rows[project] = series
+    return drift, rows, missing
+
+
+def refresh_collection_metadata(project, series):
+    """Rewrite the WESM-derived fields of one collection in place.
+
+    Orders of magnitude cheaper than a rebuild: no titiler round trip, and the
+    tile set is untouched. Collection summaries and temporal extent are always
+    rewritten; item start_datetime/end_datetime only when the collect range
+    actually moved (rare, and the expensive case -- every item file in the
+    collection). Returns the number of item files rewritten.
+    """
+    # the same string the builder hands titiler, so a metadata refresh and a full
+    # rebuild land on identical datetimes
+    start, end = create_static_stac.get_titiler_datetime(series).split("/")
+    if "NaT" in start or "NaT" in end:
+        raise ValueError(f"unusable WESM collect range ({start}/{end})")
+
+    path = CATALOG_DIR / project / "collection.json"
+    collection = json.loads(path.read_text())
+    summaries = collection.get("summaries", {})
+    for key in [k for k in summaries if k.startswith("wesm:")]:
+        del summaries[key]
+    summaries.update(create_static_stac.wesm_summary_fields(series))
+    collection["summaries"] = summaries
+    collection["extent"]["temporal"]["interval"] = [[start, end]]
+    path.write_text(json.dumps(collection, indent=2))
+
+    n_items = 0
+    for item_path in sorted((CATALOG_DIR / project).glob("*.json")):
+        if item_path.name == "collection.json":
+            continue
+        item = json.loads(item_path.read_text())
+        props = item.get("properties", {})
+        if props.get("start_datetime") == start and props.get("end_datetime") == end:
+            continue
+        props["start_datetime"] = start
+        props["end_datetime"] = end
+        item_path.write_text(json.dumps(item, indent=2))
+        n_items += 1
+    return n_items
 
 
 # ------------------------------------------------------------------ rebuild
@@ -225,17 +337,26 @@ def render_pr_body(summary, run_url=None):
         f"`{p}`", f"+{d['added']}" if d["added"] else "—",
         f"−{d['removed']}" if d["removed"] else "—"))
     pruned = rows("pruned", lambda p, d: (f"`{p}`", f"−{d['removed']}"))
+    metadata = rows("metadata", lambda p, d: (
+        f"`{p}`",
+        ", ".join(f"`{f.removeprefix('wesm:')}`" for f in d["fields"]),
+        d.get("items_updated") or "—"))
 
     added, removed = summary["tiles_added"], summary["tiles_removed"]
     before = summary["catalog_items_before"]
     after = summary.get("catalog_items_after")
 
+    counts = [f"{len(new)} new", f"{len(rebuilt)} rebuilt", f"{len(pruned)} pruned"]
+    if metadata:
+        counts.append(f"{len(metadata)} metadata-only")
+
     out = [
         "Automated run of `pixi run refresh` — S3 diff, incremental rebuild, "
-        "prune, HEAD validation (see `scripts/refresh_catalog.py`).",
+        "prune, WESM metadata refresh, HEAD validation "
+        "(see `scripts/refresh_catalog.py`).",
         "",
         f"**+{added:,} / −{removed:,} tiles** across {len(details):,} collections "
-        f"— {len(new)} new, {len(rebuilt)} rebuilt, {len(pruned)} pruned.",
+        f"— {', '.join(counts)}.",
         "",
         f"Catalog items: {before:,}" + (f" → **{after:,}**" if after else ""),
         "",
@@ -244,7 +365,22 @@ def render_pr_body(summary, run_url=None):
     out.append(_section("Rebuilt collections", rebuilt,
                         ["Collection", "Added", "Removed"]))
     out.append(_section("Pruned collections", pruned, ["Collection", "Tiles"]))
+    # tiles untouched: only WESM-derived collection metadata moved, plus item
+    # datetimes in the collections whose collect range itself changed
+    out.append(_section("WESM metadata updates", metadata,
+                        ["Collection", "Fields", "Items updated"]))
 
+    if summary.get("wesm_missing_projects"):
+        names = summary["wesm_missing_projects"]
+        shown = ", ".join(f"`{p}`" for p in names[:10])
+        more = f" … and {len(names) - 10} more" if len(names) > 10 else ""
+        out.append(f"> **No WESM row:** {shown}{more} — cataloged but no longer "
+                   "resolvable in `WESM.csv`; metadata left untouched (the tiles are "
+                   "diffed against S3 independently).\n")
+    if summary.get("metadata_failures"):
+        names = ", ".join(f"`{p}`" for p in summary["metadata_failures"])
+        out.append(f"> **⚠️ Metadata refresh failed:** {names} — previous values kept, "
+                   "retried next run.\n")
     if summary.get("carried_empty_projects"):
         names = ", ".join(f"`{p}`" for p in summary["carried_empty_projects"])
         out.append(f"> **Carried, not pruned:** {names} — TIFF listing empty but the "
@@ -304,6 +440,14 @@ def main():
                     help="abort if the diff would remove more tiles than this")
     ap.add_argument("--allow-large-removals", action="store_true",
                     help="override --max-removed-tiles after human review")
+    ap.add_argument("--skip-wesm-check", action="store_true",
+                    help="skip the WESM summary comparison (tile diff only)")
+    # a WESM schema change (column added or renamed) drifts every collection at
+    # once -- a legitimate but very large diff, so make a human confirm it
+    ap.add_argument("--max-metadata-updates", type=int, default=300,
+                    help="abort if more cataloged collections than this drifted in WESM")
+    ap.add_argument("--allow-large-metadata-updates", action="store_true",
+                    help="override --max-metadata-updates after human review")
     ap.add_argument("--sample-new", type=int, default=200,
                     help="max new/changed item URLs to HEAD-check (all must be 200)")
     ap.add_argument("--sample-existing", type=int, default=300,
@@ -368,6 +512,15 @@ def main():
                   f"(HEAD codes {codes}) -- carrying unchanged, will re-probe "
                   "next run", flush=True)
 
+    # WESM revisions that add or remove no tiles are invisible to the diff above,
+    # so compare the snapshotted collection summaries too (issue #18). Projects
+    # about to be rebuilt or pruned are skipped: a rebuild re-reads WESM anyway,
+    # and a failed rebuild leaves the drift to be caught next run.
+    wesm_drift, wesm_rows, wesm_missing = {}, {}, []
+    if not args.skip_wesm_check:
+        wesm_drift, wesm_rows, wesm_missing = wesm_diff(
+            sorted(set(local) - set(changed) - set(removed)))
+
     # Per-project tile deltas, computed once and reused by the console log, the
     # summary JSON and the PR body table.
     details = {}
@@ -379,6 +532,9 @@ def main():
                       "removed": len(local[p] - set(holdings[p]))}
     for p in removed:
         details[p] = {"action": "pruned", "added": 0, "removed": len(local[p])}
+    for p, fields in sorted(wesm_drift.items()):
+        details[p] = {"action": "metadata", "added": 0, "removed": 0,
+                      "fields": fields, "items_updated": 0}
 
     n_tiles_added = sum(d["added"] for d in details.values())
     n_tiles_removed = sum(d["removed"] for d in details.values())
@@ -394,18 +550,32 @@ def main():
         print(f"  CHANGED  {p} (+{details[p]['added']} / -{details[p]['removed']})")
     for p in removed:
         print(f"  REMOVED  {p} ({details[p]['removed']} tiles)")
+    for p, fields in sorted(wesm_drift.items()):
+        names = ", ".join(f.removeprefix("wesm:") for f in fields)
+        print(f"  METADATA {p} ({names})")
+    if wesm_missing:
+        print(f"  {len(wesm_missing)} cataloged collections have no WESM row "
+              f"(metadata left untouched): {', '.join(wesm_missing[:10])}"
+              + (" ..." if len(wesm_missing) > 10 else ""))
 
-    changed_any = bool(new or changed or removed)
+    changed_any = bool(new or changed or removed or wesm_drift)
     summary = {
         "s3_projects": len(holdings), "s3_tiles": n_s3,
         "catalog_projects_before": len(local), "catalog_items_before": n_local,
         "new_projects": new, "changed_projects": changed, "removed_projects": removed,
         "carried_empty_projects": carried_empty,
+        "metadata_projects": sorted(wesm_drift), "wesm_missing_projects": wesm_missing,
         "tiles_added": n_tiles_added, "tiles_removed": n_tiles_removed,
-        "dry_run": args.dry_run, "build_failures": [], "details": details,
+        "dry_run": args.dry_run, "build_failures": [], "metadata_failures": [],
+        "details": details,
     }
-    # "+1429/-678 tiles" -- short enough for a PR/commit title on its own
+    # "+1429/-678 tiles" -- short enough for a PR/commit title on its own; a
+    # metadata-only run has no tile delta to report, so it names itself
     title = f"+{n_tiles_added}/-{n_tiles_removed} tiles"
+    if wesm_drift:
+        title += f", {len(wesm_drift)} WESM metadata"
+    if not (new or changed or removed):
+        title = f"WESM metadata for {len(wesm_drift)} collections"
 
     if not changed_any:
         print("no changes -- catalog is current")
@@ -420,6 +590,13 @@ def main():
         sys.exit(f"GUARDRAIL: refusing to remove {n_tiles_removed} tiles "
                  f"(> {args.max_removed_tiles}); rerun with --allow-large-removals "
                  "after reviewing the diff")
+
+    if (len(wesm_drift) > args.max_metadata_updates
+            and not args.allow_large_metadata_updates and not args.dry_run):
+        sys.exit(f"GUARDRAIL: {len(wesm_drift)} collections drifted in WESM "
+                 f"(> {args.max_metadata_updates}); a WESM schema change hits every "
+                 "collection at once -- review the diff, then rerun with "
+                 "--allow-large-metadata-updates")
 
     if args.dry_run:
         print("dry run -- exiting before rebuild")
@@ -454,6 +631,25 @@ def main():
             if f.name != "collection.json" and f.stem not in keep:
                 f.unlink()
     built_new = [p for p in new if p not in failures]
+
+    # metadata-only refreshes, before the meta collection is regenerated below
+    # (create_root_collection unions the per-collection temporal extents this
+    # step can move). A failure here is per-collection and non-fatal: the old
+    # values stay put and the drift is re-detected next run.
+    metadata_failures, n_items_touched = [], 0
+    for p in sorted(wesm_drift):
+        try:
+            n = refresh_collection_metadata(p, wesm_rows[p])
+        except Exception as e:
+            metadata_failures.append(p)
+            details.pop(p, None)
+            print(f"  {p}: metadata refresh failed ({e})", flush=True)
+            continue
+        details[p]["items_updated"] = n
+        n_items_touched += n
+        print(f"  METADATA {p}: summaries updated"
+              + (f", {n} item datetimes rewritten" if n else ""), flush=True)
+
     sync_root_catalog(removed=removed)
     # add new children + regenerate the meta collection (catalog/collection.json)
     import update_root_catalog
@@ -502,13 +698,20 @@ def main():
         parts.append(f"rebuilt: {', '.join(changed)}")
     if removed:
         parts.append(f"pruned: {', '.join(removed)}")
+    metadata_done = sorted(p for p in wesm_drift if p not in metadata_failures)
+    if metadata_done:
+        parts.append(f"metadata: {', '.join(metadata_done)}")
     if failures:
         parts.append(f"FAILED: {', '.join(failures)}")
+    if metadata_failures:
+        parts.append(f"METADATA FAILED: {', '.join(metadata_failures)}")
     changelog = "; ".join(parts)
 
     n_after = sum(len(v) for v in catalog_state().values())
     summary.update({
         "catalog_items_after": n_after, "build_failures": failures,
+        "metadata_projects": metadata_done, "metadata_failures": metadata_failures,
+        "metadata_items_updated": n_items_touched,
         "changelog": changelog, "elapsed_s": round(time.time() - t0, 1),
     })
     if args.summary:
@@ -518,7 +721,7 @@ def main():
     # `title` and `subject` stay short enough to read in a PR list / git log;
     # the exhaustive project list lives in the PR body table and the summary JSON
     subject = (f"{title} ({len(new)} new, {len(changed)} rebuilt, "
-               f"{len(removed)} pruned)")
+               f"{len(removed)} pruned, {len(metadata_done)} metadata)")
     github_output(changed="true", changelog=changelog, title=title,
                   subject=subject, n_items=n_after, n_failures=len(failures))
     print(f"\nrefresh complete in {summary['elapsed_s']}s: {changelog}")

--- a/scripts/refresh_catalog.py
+++ b/scripts/refresh_catalog.py
@@ -107,11 +107,15 @@ def discover_s3(threads=8):
 
 
 # ------------------------------------------------------------ local catalog
-def catalog_state():
-    """{project: {item_id}} for the local static catalog (item JSON files)."""
+def catalog_state(only=None):
+    """{project: {item_id}} for the local static catalog (item JSON files).
+
+    `only` restricts it to the named projects, so the before/after item counts
+    stay on the same footing when --only narrows the run.
+    """
     state = {}
     for coll in sorted(CATALOG_DIR.iterdir()):
-        if not coll.is_dir():
+        if not coll.is_dir() or (only is not None and coll.name not in only):
             continue
         ids = {p.stem for p in coll.glob("*.json") if p.name != "collection.json"}
         state[coll.name] = ids
@@ -468,13 +472,12 @@ def main():
 
     t0 = time.time()
     holdings, folders = discover_s3(threads=args.threads)
-    local = catalog_state()
+    only = set(args.only) if args.only else None
+    local = catalog_state(only)
 
-    if args.only:
-        only = set(args.only)
+    if only:
         holdings = {p: v for p, v in holdings.items() if p in only and v}
         folders = folders & only
-        local = {p: v for p, v in local.items() if p in only}
     elif len(holdings) < args.min_projects:
         sys.exit(f"GUARDRAIL: only {len(holdings)} projects listed on S3 "
                  f"(< {args.min_projects}); bucket may be mid-repopulation (see issue #6)")
@@ -543,7 +546,8 @@ def main():
 
     print(f"\ncatalog items: {n_local}  |  S3 tifs: {n_s3}")
     print(f"diff: +{n_tiles_added} tiles / -{n_tiles_removed} tiles  "
-          f"({len(new)} new, {len(changed)} changed, {len(removed)} removed projects)")
+          f"({len(new)} new, {len(changed)} changed, {len(removed)} removed, "
+          f"{len(wesm_drift)} metadata-only projects)")
     for p in new:
         print(f"  NEW      {p} ({details[p]['added']} tiles)")
     for p in changed:
@@ -677,7 +681,7 @@ def main():
     # HEAD-checked above, and including them would bias this gate away from
     # its purpose -- catching 404 drift in projects the run didn't touch
     rebuilt_ok = {p for p in changed if p not in failures} | set(built_new)
-    carried = [(p, i) for p, ids in catalog_state().items()
+    carried = [(p, i) for p, ids in catalog_state(only).items()
                for i in ids
                if p not in rebuilt_ok and p in local and i in local.get(p, set())]
     sample = random.sample(carried, min(args.sample_existing, len(carried)))
@@ -707,7 +711,7 @@ def main():
         parts.append(f"METADATA FAILED: {', '.join(metadata_failures)}")
     changelog = "; ".join(parts)
 
-    n_after = sum(len(v) for v in catalog_state().values())
+    n_after = sum(len(v) for v in catalog_state(only).values())
     summary.update({
         "catalog_items_after": n_after, "build_failures": failures,
         "metadata_projects": metadata_done, "metadata_failures": metadata_failures,


### PR DESCRIPTION
Closes #18.

## The gap

A rebuild triggered only on tile-set change, so a WESM revision that added or removed no tiles never reached the catalog. Collection `wesm:*` summaries are snapshotted at build time, and every item's `start_datetime`/`end_datetime` derives from WESM `collect_start`/`collect_end` — the field SlideRule's AMS `3DEP1M` table keys on (#11), where a stale value is a wrong answer rather than a missing one.

## The fix

`refresh_catalog.py` now compares each `collection.json`'s snapshotted summaries against live `WESM.csv` on every run (`wesm_diff`) and repairs the drifted collections **in place** (`refresh_collection_metadata`):

- collection `wesm:*` summaries,
- collection temporal extent,
- item `start_datetime`/`end_datetime` — **only** when the collect range actually moved, so a category/pub-date revision touches one file instead of thousands.

No titiler round trip and the tile set is untouched, so it costs ~1 s on top of a dry run instead of a rebuild. The metadata pass runs before `create_root_catalog`'s meta-collection regeneration, since it can move the temporal extents that union into it.

Both sides of the comparison go through the new `create_static_stac.wesm_summary_fields()`, so a serialization difference cannot masquerade as drift. Projects already queued for rebuild or prune are skipped (a rebuild re-reads WESM anyway). A folder name that no longer resolves in WESM is *reported, never modified* — WESM dropping a workunit says nothing about whether the tiles are still staged, and that is the S3 diff's job.

### Guardrails / flags

- `--max-metadata-updates` (default 300, override `--allow-large-metadata-updates`, also a `workflow_dispatch` input) — a WESM schema change would drift every collection at once; that is a legitimate but very large diff and should get a human look first.
- `--skip-wesm-check` falls back to the tile-only diff.
- A per-collection failure is non-fatal: old values stay put, the drift is re-detected next run, and the PR body flags it.

## What the first run will do

Measured against live `WESM.csv` today — **192 of 946 collections drift**, 105 of them in the collect range (~39k item files carrying wrong datetimes):

| Field | Collections |
| --- | ---: |
| `workunit` / `workunit_id` | 115 |
| `lpc_pub_date` | 108 |
| `sourcedem_pub_date` | 106 |
| `collect_end` | 105 |
| `horiz_crs` | 44 |
| `sourcedem_update` | 33 |
| `dem_gsd_meters` | 30 |
| `lpc_update` | 22 |
| `ql` | 19 |
| `*_category` / `*_reason` | 13–14 each |
| `spec`, `vert_crs`, `geoid`, `p_method` | 3–8 each |

That is well above issue #18's estimate because the backlog is not only USGS revisions: it also includes the `collapse_workunit_rows` fix (deterministic representative row, min/max collect range across multi-workunit projects) that collections built before it never picked up. E.g. `WY_GrandTetonNP_D22` `collect_end` `2023/10/20` → `2024/08/01` (max across its 3 workunits), `WA_KingCounty_2021_B21` `2021/04/24` → `2021/09/07` plus `Pending publication` → `Meets`.

**This PR is code only** — no catalog changes. The backfill lands with the next `refresh` run (weekly cron or manual dispatch), under the 300 guardrail, and its PR body itemizes every collection and field.

## Verification

- Sandbox copy of a real collection: drift detected on exactly the perturbed fields; after refresh, both `collection.json` and every item file are **byte-identical** to the committed originals apart from the WESM-derived fields; second pass is a no-op; an unresolvable name lands in `missing` and is left alone.
- Full `--dry-run` against live S3 + WESM: 9.4 s, PR body renders (17 KB, well under GitHub's limit).
- Full non-dry `refresh --only WA_KingCounty_2021_B21` in a sandbox catalog: summaries + extent + 91 item datetimes updated, root/meta collection regenerated, HEAD validation clean, `pystac` reads the result back.
- Rebuilt `NM_RioSanJose_2016` from scratch with the refactored builder: summaries and temporal extent identical to the committed collection, and identical to what the refresh path computes for the same project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)