### PR TITLE
Scope ruff to scripts/ and gate PRs on it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+# Ruff lint + format gate for pull requests.
+#
+# Scope is whatever ruff.toml includes (scripts/ only) -- notebooks/ and
+# checkpoints/ are deliberately out of it, so nothing here fires on exploratory
+# work. Reproduce a failure locally with `pixi run lint`, fix with `pixi run ruff`.
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: prefix-dev/setup-pixi@v0.10.1
+        with:
+          cache: true
+
+      # `ruff check` annotates offending lines on the PR diff; `ruff format
+      # --diff` prints the reformatting it would apply and exits non-zero
+      - name: Ruff check + format
+        run: pixi run lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,10 @@ pixi run collection2geoparquet catalog/<ID>/collection.json out.parquet
 pixi run update-root-catalog       # link new children into catalog/catalog.json
 pixi run list-collections          # regenerate collections.txt
 pixi run ruff                      # ruff check --fix + ruff format
+pixi run lint                      # non-mutating check + format --diff (the CI gate)
 ```
+
+Ruff is scoped to `scripts/` by `include` in `ruff.toml` — `notebooks/` and `checkpoints/` are exploratory and several cells hold pasted shell output ruff cannot parse, so never widen that scope to "fix" a lint error there.
 
 There is no test suite. `catalog2geoparquet` opens one file handle per item (~124k), hence the `ulimit -n` bump.
 
@@ -55,6 +58,7 @@ Some folders have no TIFFs at all; those are listed in `NO_TIFFS` in `create_all
 ### Automation
 
 * `.github/workflows/update-catalog.yml` — weekly (Mon 06:00 UTC) + `workflow_dispatch` (`dry_run`, `allow_large_removals`). Runs `pixi run refresh` and opens a PR; no PR when nothing changed.
+* `.github/workflows/lint.yml` — `pixi run lint` on every PR and push to `main`; fails on a ruff lint error or an unformatted file under `scripts/`.
 * `.github/workflows/release.yml` — monthly (1st, 06:17 UTC) + dispatch. Skips if `catalog/` is unchanged since the latest release *tag* (resolved via the tag, not `targetCommitish`). Otherwise rebuilds the parquet, asserts parquet row count == item-file count, writes `catalog.gti`, and publishes a CalVer `vYYYY.MM.DD` release so `releases/latest/download/catalog.parquet` stays current.
 
 `refresh_catalog.py` is the interesting one — it is destructive by design and its guardrails exist because the USGS bucket has been observed mid-repopulation (issue #6):

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,7 +15,8 @@ catalog2hive = { cmd = "python scripts/catalog2hive.py", description = "Write th
 create-collection-parquets = { cmd = "python scripts/create_collection_parquets.py", description = "Write a .parquet next to each collection.json under a catalog directory" }
 update-root-catalog = { cmd = "python scripts/update_root_catalog.py", description = "Add any new child collections to the top-level catalog.json" }
 list-collections = { cmd = "ls -1d catalog/*/ | sed 's|catalog/||;s|/||' > collections.txt", description = "Write the list of collection IDs in catalog/ to collections.txt" }
-ruff = { cmd = "ruff check --fix ; ruff format", description = "Lint with autofix and format the codebase using ruff" }
+ruff = { cmd = "ruff check --fix ; ruff format", description = "Lint with autofix and format scripts/ using ruff (scope set in ruff.toml)" }
+lint = { cmd = "ruff check --output-format=github && ruff format --diff", description = "Check lint + formatting without modifying anything; what CI gates PRs on" }
 
 [dependencies]
 arro3-core = ">=0.6.3,<0.7"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+# Lint and format scripts/ only.
+#
+# notebooks/ and checkpoints/ are exploratory: cells carry pasted shell output and
+# GDAL logs that ruff cannot parse, so a repo-wide `ruff format` both errors out on
+# them and rewrites a pile of scratch work nobody asked it to touch. Whitelisting
+# rather than excluding keeps stray .py/.ipynb files at the repo root out of scope
+# too. CI enforces this via `pixi run lint` (.github/workflows/lint.yml).
+include = ["scripts/**/*.py"]

--- a/scripts/catalog2geoparquet.py
+++ b/scripts/catalog2geoparquet.py
@@ -13,8 +13,6 @@ import rustac
 import sys
 from pathlib import Path
 
-import geopandas as gpd
-import stac_geoparquet
 
 async def collection_to_stac_geoparquet(catalog_path, output_path=None):
     """

--- a/scripts/create_all.py
+++ b/scripts/create_all.py
@@ -7,16 +7,18 @@ from botocore.client import Config
 import subprocess
 from pathlib import Path
 
-s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 # NOTE: paginate — a single list_objects_v2 call returns at most 1000 prefixes
 # and the bucket currently has ~960 project folders
-paginator = s3.get_paginator('list_objects_v2')
+paginator = s3.get_paginator("list_objects_v2")
 folders = []
-for page in paginator.paginate(Bucket='prd-tnm', Prefix='StagedProducts/Elevation/1m/Projects/', Delimiter='/'):
-    folders += [content['Prefix'] for content in page.get('CommonPrefixes', [])]
-all_folders = [x.split('/')[-2] for x in folders]
+for page in paginator.paginate(
+    Bucket="prd-tnm", Prefix="StagedProducts/Elevation/1m/Projects/", Delimiter="/"
+):
+    folders += [content["Prefix"] for content in page.get("CommonPrefixes", [])]
+all_folders = [x.split("/")[-2] for x in folders]
 
-print('Located {} folders in S3...'.format(len(all_folders)))
+print("Located {} folders in S3...".format(len(all_folders)))
 
 # For some reason these are mising TIFFs
 NO_TIFFS = [
@@ -45,21 +47,29 @@ NO_TIFFS = [
 ]
 
 # For efficiency only work with folders that don't already have a STAC
-catalog_path = Path('catalog')
+catalog_path = Path("catalog")
 subfolders = [f.name for f in catalog_path.iterdir() if f.is_dir()]
 missing_folders = set(all_folders) - set(subfolders) - set(NO_TIFFS)
 
-print('Processing {} folders without local STAC...'.format(len(missing_folders)))
-print('\n'.join(sorted(missing_folders)))
+print("Processing {} folders without local STAC...".format(len(missing_folders)))
+print("\n".join(sorted(missing_folders)))
 
 # Non-elegant approach to creating all STACs for workunit or project
 for i, project in enumerate(missing_folders):
     print(i, project)
     try:
-        subprocess.run(['./scripts/create_static_stac.py', '--workunit', project], check=True, capture_output=False)
+        subprocess.run(
+            ["./scripts/create_static_stac.py", "--workunit", project],
+            check=True,
+            capture_output=False,
+        )
     except subprocess.CalledProcessError:
-        print('Failed processing as WESM Workunit, trying as Project...')
+        print("Failed processing as WESM Workunit, trying as Project...")
         try:
-            subprocess.run(['./scripts/create_static_stac.py', '--project', project], check=True, capture_output=True)
+            subprocess.run(
+                ["./scripts/create_static_stac.py", "--project", project],
+                check=True,
+                capture_output=True,
+            )
         except subprocess.CalledProcessError:
-            print('Failed processing as Project... skipping.')
+            print("Failed processing as Project... skipping.")

--- a/scripts/create_static_stac.py
+++ b/scripts/create_static_stac.py
@@ -35,7 +35,8 @@ import time
 import boto3
 from botocore import UNSIGNED
 from botocore.client import Config
-s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+
+s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
 # explicitly instantiate a client that always uses the local cache
 client = S3Client(local_cache_dir="/tmp", no_sign_request=True)
@@ -51,7 +52,7 @@ onemeter_folder_to_wesm = {
     "CA_Eastern_SanDiegoCo_2016": "CA_E_SanDiegoCo_2016",
     "CA_SanDiegoCo_2016": "CA_SanDiego_2015_C17_1",
     "CA_Sonoma_A1_2013": "CA_Sonoma_2013",
-    'CO_MesaCo_QL2_UTM12_2016' : 'CO_MesaCo_QL2_2015',
+    "CO_MesaCo_QL2_UTM12_2016": "CO_MesaCo_QL2_2015",
     "Elwha_River_LiDAR_2014_MOD2": "WA_ElwhaRiver_2014",
     "IL_12_County_HenryCO_2009": "IL_12_County_HenryCo_2009",
     "IL_KankakeeCo_2014": "IL_5County_KankakeeCo_2014",
@@ -76,22 +77,23 @@ onemeter_folder_to_wesm = {
     "NY_Southwest_2_Co_2016": "NY_Southwest_2_CO_2016",
     "OR_Wallowa_2015": "OR_OLC_Wallowa_2015",
     "SD_NRCS_Fugro_B2_TL_2017": "SD_NRCS_Fugro_B2_2017",
-    #"TN_NRCS_2011": but "TN_NRCS_L2_2011_12" or 'TN_NRCS_L1_2011_12' also present?... L2 matches TIFF XML rngdates so I'll use that
+    # "TN_NRCS_2011": but "TN_NRCS_L2_2011_12" or 'TN_NRCS_L1_2011_12' also present?... L2 matches TIFF XML rngdates so I'll use that
     "TN_NRCS_2011": "TN_NRCS_L2_2011_12",
-    "UT_Area1WasatchFault_2013": "UT_Wasatch_L4_2013", # note: unsure, use most recent sourcedem update...
+    "UT_Area1WasatchFault_2013": "UT_Wasatch_L4_2013",  # note: unsure, use most recent sourcedem update...
     "UT_MonroeMountain_2016": "UT_MonroeMoutain_2016",
     "UT_Wasatch_L3_2013": "UT_WasatchFault_L3_2013",
     # PROBLEM: 3 different workunits B1, B2, B3.... should use merge of 3 but code is currently setup to just pick one...
-    "VA_FEMA-NRCS_SouthCentral_2017_D17":"VA_South_Central_B2_2017",
+    "VA_FEMA-NRCS_SouthCentral_2017_D17": "VA_South_Central_B2_2017",
 }
 # XML metadata https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1m/Projects/VA_FEMA-NRCS_SouthCentral_2017_D17/metadata/USGS_1M_17_x35y422_VA_FEMA-NRCS_SouthCentral_2017_D17.xml
-#<begdate>20170414</begdate>
-#<enddate>20180524</enddate>
+# <begdate>20170414</begdate>
+# <enddate>20180524</enddate>
 # VA_FEMA-NRCS_SouthCentral_2017_D17
 #                      workunit collect_start collect_end
-#1703  VA_South_Central_B2_2017    2017/04/14  2017/12/06
-#1704  VA_South_Central_B3_2017    2017/04/14  2017/12/07
-#1836  VA_South_Central_B1_2017    2017/11/16  2018/05/24
+# 1703  VA_South_Central_B2_2017    2017/04/14  2017/12/06
+# 1704  VA_South_Central_B3_2017    2017/04/14  2017/12/07
+# 1836  VA_South_Central_B1_2017    2017/11/16  2018/05/24
+
 
 def get_titiler_datetime(series):
     start = pd.to_datetime(series.collect_start).isoformat() + "Z"
@@ -99,6 +101,7 @@ def get_titiler_datetime(series):
     datestr = f"{start}/{end}"
     # print(datestr)
     return datestr
+
 
 # def add_wesm_metadata_to_properties(item, series):
 #     '''add all WESM metadata with wesm: prefix to STAC properties inplace'''
@@ -131,6 +134,7 @@ def add_wesm_metadata_to_collection(collection, series):
 # https://github.com/developmentseed/titiler/discussions/1223
 # Should deploy our own version anyways
 
+
 # TODO: use aiohttp instead?
 # How to code async functions in a synchronous script...
 def create_stac_item(URL, DATETIME):
@@ -145,13 +149,15 @@ def create_stac_item(URL, DATETIME):
         "with_eo": "false",
         "url": URL,
     }
-    #stacify = f"https://titiler.xyz/cog/stac"
-    stacify = "https://xpohtuqdoyg4w7ze7loqenojje0earua.lambda-url.us-west-2.on.aws/cog/stac"
+    # stacify = f"https://titiler.xyz/cog/stac"
+    stacify = (
+        "https://xpohtuqdoyg4w7ze7loqenojje0earua.lambda-url.us-west-2.on.aws/cog/stac"
+    )
 
     # Test:
     # https://xpohtuqdoyg4w7ze7loqenojje0earua.lambda-url.us-west-2.on.aws/cog/stac?id=USGS_1M_16_x24y472_WI_Statewide_2019_A19&datetime=2019-04-08T00:00:00Z/2019-04-08T00:00:00Z&collection=WI_Statewide_2019_A19&asset_name=elevation&asset_roles=data&with_eo=false&url=https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1m/Projects/WI_Statewide_2019_A19/TIFF/USGS_1M_16_x24y472_WI_Statewide_2019_A19.tif
 
-    #print(f"Requesting STAC item for {ID}")
+    # print(f"Requesting STAC item for {ID}")
     # timeout so one wedged connection can't stall an unattended run's batch,
     # with a short bounded retry on connection errors/timeouts
     TIMEOUT = (10, 120)  # (connect, read) seconds
@@ -161,7 +167,7 @@ def create_stac_item(URL, DATETIME):
             break
         except requests.RequestException as e:
             print(f"{ID}: {e} (attempt {attempt + 1})")
-            time.sleep(2 ** attempt)
+            time.sleep(2**attempt)
     else:
         raise RuntimeError(f"titiler request failed repeatedly for {URL}")
 
@@ -177,11 +183,10 @@ def create_stac_item(URL, DATETIME):
             if r.json().get("detail", "").startswith("Too many bins for data range"):
                 params["with_raster"] = "false"
                 r = requests.get(stacify, params=params, timeout=TIMEOUT)
-        else: # internal server errors seem to be 502?
+        else:  # internal server errors seem to be 502?
             # just retry after a moment
             time.sleep(1)
             r = requests.get(stacify, params=params, timeout=TIMEOUT)
-
 
     return r.text
 
@@ -241,7 +246,7 @@ def get_wesm_series(project, is_workunit=False, df=None, warn=True):
     if project in onemeter_folder_to_wesm:
         name = onemeter_folder_to_wesm[project]
         # NOTE: maybe issue here in cases of updated processing? check for source_dem update?
-        #.e.g. TN_NRCS_L2_2011_12
+        # .e.g. TN_NRCS_L2_2011_12
         rows = df[df.workunit == name]
         if rows.empty:
             raise ValueError(
@@ -251,7 +256,9 @@ def get_wesm_series(project, is_workunit=False, df=None, warn=True):
     else:
         if is_workunit:
             if project not in df.workunit.values:
-                alternatives = df[df.workunit.str.startswith(project)].workunit.to_list()
+                alternatives = df[
+                    df.workunit.str.startswith(project)
+                ].workunit.to_list()
                 raise ValueError(
                     f"Workunit '{project}' not found in WESM metadata, close matches: {alternatives}"
                 )
@@ -292,7 +299,7 @@ def generate_stac_from_titiler(tiflist, DATETIME):
     # waiting on quota increase... from 10 to 1000 :)
     def batch_urls(urls, batch_size=100):
         for i in range(0, len(urls), batch_size):
-            yield urls[i:i + batch_size]
+            yield urls[i : i + batch_size]
 
     results = []
     for batch in batch_urls(tiflist):
@@ -346,12 +353,13 @@ def list_tiffs_in_project(project, bucket="prd-tnm"):
     # NOTE: must paginate! A single list_objects_v2 call returns at most 1000
     # keys, which silently truncated projects with >1000 tiles (e.g. OR_SouthEast_D22)
     project_prefix = f"StagedProducts/Elevation/1m/Projects/{project}/TIFF"
-    paginator = s3.get_paginator('list_objects_v2')
+    paginator = s3.get_paginator("list_objects_v2")
     tiff_files = []
     for page in paginator.paginate(Bucket=bucket, Prefix=project_prefix):
         tiff_files += [
-            obj['Key'] for obj in page.get('Contents', [])
-            if obj['Key'].endswith('.tif')
+            obj["Key"]
+            for obj in page.get("Contents", [])
+            if obj["Key"].endswith(".tif")
         ]
 
     return [f"https://{bucket}.s3.amazonaws.com/{key}" for key in tiff_files]
@@ -363,8 +371,8 @@ def create_stac_catalog(project, is_workunit=False):
 
     # NOTE: not all folders have 0_file_download_links.txt
     # or 0_file_download_links.txt has errors
-    #project_inventory = f"s3://prd-tnm/StagedProducts/Elevation/1m/Projects/{project}/0_file_download_links.txt"
-    #tiflist = get_tif_list_s3(project_inventory)
+    # project_inventory = f"s3://prd-tnm/StagedProducts/Elevation/1m/Projects/{project}/0_file_download_links.txt"
+    # tiflist = get_tif_list_s3(project_inventory)
 
     # Instead list TIFF/ folder directly
     tiflist = list_tiffs_in_project(project)

--- a/scripts/refresh_catalog.py
+++ b/scripts/refresh_catalog.py
@@ -70,7 +70,9 @@ def list_project_folders():
     """All project folder names under the 1m Projects/ prefix (paginated)."""
     paginator = s3.get_paginator("list_objects_v2")
     folders = []
-    for page in paginator.paginate(Bucket=BUCKET, Prefix=PROJECTS_PREFIX, Delimiter="/"):
+    for page in paginator.paginate(
+        Bucket=BUCKET, Prefix=PROJECTS_PREFIX, Delimiter="/"
+    ):
         folders += [c["Prefix"].split("/")[-2] for c in page.get("CommonPrefixes", [])]
     return folders
 
@@ -148,8 +150,9 @@ def wesm_row(project, df):
     """
     for is_workunit in (True, False):
         try:
-            return create_static_stac.get_wesm_series(project, is_workunit=is_workunit,
-                                                      df=df, warn=False)
+            return create_static_stac.get_wesm_series(
+                project, is_workunit=is_workunit, df=df, warn=False
+            )
         except (ValueError, KeyError, IndexError):
             continue
     return None
@@ -296,7 +299,9 @@ def head_check(urls, label, threads=8):
         codes = list(ex.map(head_status, urls))
     n404 = sum(1 for c in codes if c == 404)
     nerr = sum(1 for c in codes if c not in (200, 404))
-    print(f"HEAD {label}: {len(codes)} checked, {n404} x 404, {nerr} errors", flush=True)
+    print(
+        f"HEAD {label}: {len(codes)} checked, {n404} x 404, {nerr} errors", flush=True
+    )
     return len(codes), n404, nerr
 
 
@@ -307,8 +312,10 @@ PR_BODY_MAX_ROWS = 150
 
 
 def _table(rows, headers):
-    out = ["| " + " | ".join(headers) + " |",
-           "| " + " | ".join(["---"] + ["---:"] * (len(headers) - 1)) + " |"]
+    out = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(["---"] + ["---:"] * (len(headers) - 1)) + " |",
+    ]
     for r in rows[:PR_BODY_MAX_ROWS]:
         out.append("| " + " | ".join(str(c) for c in r) + " |")
     if len(rows) > PR_BODY_MAX_ROWS:
@@ -322,8 +329,10 @@ def _section(title, rows, headers, collapse_over=25):
         return ""
     body = _table(rows, headers)
     if len(rows) > collapse_over:
-        return (f"<details>\n<summary><b>{title}</b> (click to expand)</summary>\n\n"
-                f"{body}\n\n</details>\n")
+        return (
+            f"<details>\n<summary><b>{title}</b> (click to expand)</summary>\n\n"
+            f"{body}\n\n</details>\n"
+        )
     return f"#### {title}\n\n{body}\n"
 
 
@@ -333,18 +342,26 @@ def render_pr_body(summary, run_url=None):
     failures = set(summary.get("build_failures") or [])
 
     def rows(action, cols):
-        return [cols(p, d) for p, d in sorted(details.items())
-                if d["action"] == action]
+        return [cols(p, d) for p, d in sorted(details.items()) if d["action"] == action]
 
     new = rows("new", lambda p, d: (f"`{p}`", f"+{d['added']}"))
-    rebuilt = rows("rebuilt", lambda p, d: (
-        f"`{p}`", f"+{d['added']}" if d["added"] else "—",
-        f"−{d['removed']}" if d["removed"] else "—"))
+    rebuilt = rows(
+        "rebuilt",
+        lambda p, d: (
+            f"`{p}`",
+            f"+{d['added']}" if d["added"] else "—",
+            f"−{d['removed']}" if d["removed"] else "—",
+        ),
+    )
     pruned = rows("pruned", lambda p, d: (f"`{p}`", f"−{d['removed']}"))
-    metadata = rows("metadata", lambda p, d: (
-        f"`{p}`",
-        ", ".join(f"`{f.removeprefix('wesm:')}`" for f in d["fields"]),
-        d.get("items_updated") or "—"))
+    metadata = rows(
+        "metadata",
+        lambda p, d: (
+            f"`{p}`",
+            ", ".join(f"`{f.removeprefix('wesm:')}`" for f in d["fields"]),
+            d.get("items_updated") or "—",
+        ),
+    )
 
     added, removed = summary["tiles_added"], summary["tiles_removed"]
     before = summary["catalog_items_before"]
@@ -366,40 +383,54 @@ def render_pr_body(summary, run_url=None):
         "",
     ]
     out.append(_section("New collections", new, ["Collection", "Tiles"]))
-    out.append(_section("Rebuilt collections", rebuilt,
-                        ["Collection", "Added", "Removed"]))
+    out.append(
+        _section("Rebuilt collections", rebuilt, ["Collection", "Added", "Removed"])
+    )
     out.append(_section("Pruned collections", pruned, ["Collection", "Tiles"]))
     # tiles untouched: only WESM-derived collection metadata moved, plus item
     # datetimes in the collections whose collect range itself changed
-    out.append(_section("WESM metadata updates", metadata,
-                        ["Collection", "Fields", "Items updated"]))
+    out.append(
+        _section(
+            "WESM metadata updates", metadata, ["Collection", "Fields", "Items updated"]
+        )
+    )
 
     if summary.get("wesm_missing_projects"):
         names = summary["wesm_missing_projects"]
         shown = ", ".join(f"`{p}`" for p in names[:10])
         more = f" … and {len(names) - 10} more" if len(names) > 10 else ""
-        out.append(f"> **No WESM row:** {shown}{more} — cataloged but no longer "
-                   "resolvable in `WESM.csv`; metadata left untouched (the tiles are "
-                   "diffed against S3 independently).\n")
+        out.append(
+            f"> **No WESM row:** {shown}{more} — cataloged but no longer "
+            "resolvable in `WESM.csv`; metadata left untouched (the tiles are "
+            "diffed against S3 independently).\n"
+        )
     if summary.get("metadata_failures"):
         names = ", ".join(f"`{p}`" for p in summary["metadata_failures"])
-        out.append(f"> **⚠️ Metadata refresh failed:** {names} — previous values kept, "
-                   "retried next run.\n")
+        out.append(
+            f"> **⚠️ Metadata refresh failed:** {names} — previous values kept, "
+            "retried next run.\n"
+        )
     if summary.get("carried_empty_projects"):
         names = ", ".join(f"`{p}`" for p in summary["carried_empty_projects"])
-        out.append(f"> **Carried, not pruned:** {names} — TIFF listing empty but the "
-                   "removal probe was inconclusive; re-probed next run.\n")
+        out.append(
+            f"> **Carried, not pruned:** {names} — TIFF listing empty but the "
+            "removal probe was inconclusive; re-probed next run.\n"
+        )
     if failures:
         names = ", ".join(f"`{p}`" for p in sorted(failures))
-        out.append(f"> **⚠️ Build failures:** {names} — previous version kept. Usually a "
-                   "WESM name mismatch (see `onemeter_folder_to_wesm` in "
-                   "`scripts/create_static_stac.py`).\n")
+        out.append(
+            f"> **⚠️ Build failures:** {names} — previous version kept. Usually a "
+            "WESM name mismatch (see `onemeter_folder_to_wesm` in "
+            "`scripts/create_static_stac.py`).\n"
+        )
 
     if run_url:
         out.append(f"Full diff summary in the [workflow run]({run_url}).")
-    out.append("After merging, `release.yml` (monthly cron, or manual "
-               "workflow_dispatch) rebuilds `catalog.parquet`/`catalog.gti` and "
-               "publishes a dated release.")
+    out.append(
+        "After merging, `release.yml` (monthly cron, or manual "
+        "workflow_dispatch) rebuilds `catalog.parquet`/`catalog.gti` and "
+        "publishes a dated release."
+    )
     return "\n".join(out).replace("\n\n\n", "\n\n") + "\n"
 
 
@@ -429,42 +460,92 @@ def github_output(**kwargs):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--dry-run", action="store_true",
-                    help="report the diff and exit without modifying anything")
-    ap.add_argument("--only", action="append", metavar="PROJECT",
-                    help="restrict the diff/rebuild to named project(s) (testing)")
-    ap.add_argument("--min-projects", type=int, default=900,
-                    help="abort if S3 lists fewer project folders than this")
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report the diff and exit without modifying anything",
+    )
+    ap.add_argument(
+        "--only",
+        action="append",
+        metavar="PROJECT",
+        help="restrict the diff/rebuild to named project(s) (testing)",
+    )
+    ap.add_argument(
+        "--min-projects",
+        type=int,
+        default=900,
+        help="abort if S3 lists fewer project folders than this",
+    )
     # NOTE: this cap counts tiles, not projects -- several small projects can
     # be pruned in one night without tripping it (acceptable blast radius given
     # the folder-present/items-reachable carry logic below)
-    ap.add_argument("--max-removed-tiles", type=int, default=2000,
-                    help="abort if the diff would remove more tiles than this")
-    ap.add_argument("--allow-large-removals", action="store_true",
-                    help="override --max-removed-tiles after human review")
-    ap.add_argument("--skip-wesm-check", action="store_true",
-                    help="skip the WESM summary comparison (tile diff only)")
+    ap.add_argument(
+        "--max-removed-tiles",
+        type=int,
+        default=2000,
+        help="abort if the diff would remove more tiles than this",
+    )
+    ap.add_argument(
+        "--allow-large-removals",
+        action="store_true",
+        help="override --max-removed-tiles after human review",
+    )
+    ap.add_argument(
+        "--skip-wesm-check",
+        action="store_true",
+        help="skip the WESM summary comparison (tile diff only)",
+    )
     # a WESM schema change (column added or renamed) drifts every collection at
     # once -- a legitimate but very large diff, so make a human confirm it
-    ap.add_argument("--max-metadata-updates", type=int, default=300,
-                    help="abort if more cataloged collections than this drifted in WESM")
-    ap.add_argument("--allow-large-metadata-updates", action="store_true",
-                    help="override --max-metadata-updates after human review")
-    ap.add_argument("--sample-new", type=int, default=200,
-                    help="max new/changed item URLs to HEAD-check (all must be 200)")
-    ap.add_argument("--sample-existing", type=int, default=300,
-                    help="random carried-over item URLs to HEAD-check")
-    ap.add_argument("--max-404-pct", type=float, default=1.0,
-                    help="fail if more than this %% of sampled existing URLs 404")
-    ap.add_argument("--threads", type=int, default=8,
-                    help="S3 listing / HEAD check concurrency")
-    ap.add_argument("--summary", type=Path, default=None,
-                    help="write a JSON run summary to this path")
-    ap.add_argument("--pr-body", type=Path, default=None,
-                    help="write the rendered markdown PR body to this path "
-                         "(also written on --dry-run, for local preview)")
+    ap.add_argument(
+        "--max-metadata-updates",
+        type=int,
+        default=300,
+        help="abort if more cataloged collections than this drifted in WESM",
+    )
+    ap.add_argument(
+        "--allow-large-metadata-updates",
+        action="store_true",
+        help="override --max-metadata-updates after human review",
+    )
+    ap.add_argument(
+        "--sample-new",
+        type=int,
+        default=200,
+        help="max new/changed item URLs to HEAD-check (all must be 200)",
+    )
+    ap.add_argument(
+        "--sample-existing",
+        type=int,
+        default=300,
+        help="random carried-over item URLs to HEAD-check",
+    )
+    ap.add_argument(
+        "--max-404-pct",
+        type=float,
+        default=1.0,
+        help="fail if more than this %% of sampled existing URLs 404",
+    )
+    ap.add_argument(
+        "--threads", type=int, default=8, help="S3 listing / HEAD check concurrency"
+    )
+    ap.add_argument(
+        "--summary",
+        type=Path,
+        default=None,
+        help="write a JSON run summary to this path",
+    )
+    ap.add_argument(
+        "--pr-body",
+        type=Path,
+        default=None,
+        help="write the rendered markdown PR body to this path "
+        "(also written on --dry-run, for local preview)",
+    )
     args = ap.parse_args()
 
     if not CATALOG_DIR.is_dir():
@@ -479,12 +560,15 @@ def main():
         holdings = {p: v for p, v in holdings.items() if p in only and v}
         folders = folders & only
     elif len(holdings) < args.min_projects:
-        sys.exit(f"GUARDRAIL: only {len(holdings)} projects listed on S3 "
-                 f"(< {args.min_projects}); bucket may be mid-repopulation (see issue #6)")
+        sys.exit(
+            f"GUARDRAIL: only {len(holdings)} projects listed on S3 "
+            f"(< {args.min_projects}); bucket may be mid-repopulation (see issue #6)"
+        )
 
     new = sorted(set(holdings) - set(local))
-    changed = sorted(p for p in set(holdings) & set(local)
-                     if set(holdings[p]) != local[p])
+    changed = sorted(
+        p for p in set(holdings) & set(local) if set(holdings[p]) != local[p]
+    )
 
     # Prune classification: a cataloged project with no tifs on S3 is either
     # truly deleted (folder prefix gone) or a folder remnant / mid-restage
@@ -503,17 +587,26 @@ def main():
         codes = [head_status(u) for u in urls]
         if any(c == 200 for c in codes):
             carried_empty.append(p)
-            print(f"  CARRIED  {p}: TIFF/ empty but folder present and items still "
-                  "reachable -- possible restage in progress, not pruning", flush=True)
+            print(
+                f"  CARRIED  {p}: TIFF/ empty but folder present and items still "
+                "reachable -- possible restage in progress, not pruning",
+                flush=True,
+            )
         elif codes and all(c == 404 for c in codes):
             removed.append(p)
-            print(f"  {p}: folder remnant with no tifs and all {len(codes)} probed "
-                  "items 404 -- treating as removed", flush=True)
+            print(
+                f"  {p}: folder remnant with no tifs and all {len(codes)} probed "
+                "items 404 -- treating as removed",
+                flush=True,
+            )
         else:
             carried_empty.append(p)
-            print(f"  CARRIED  {p}: TIFF/ empty but probe inconclusive "
-                  f"(HEAD codes {codes}) -- carrying unchanged, will re-probe "
-                  "next run", flush=True)
+            print(
+                f"  CARRIED  {p}: TIFF/ empty but probe inconclusive "
+                f"(HEAD codes {codes}) -- carrying unchanged, will re-probe "
+                "next run",
+                flush=True,
+            )
 
     # WESM revisions that add or remove no tiles are invisible to the diff above,
     # so compare the snapshotted collection summaries too (issue #18). Projects
@@ -522,7 +615,8 @@ def main():
     wesm_drift, wesm_rows, wesm_missing = {}, {}, []
     if not args.skip_wesm_check:
         wesm_drift, wesm_rows, wesm_missing = wesm_diff(
-            sorted(set(local) - set(changed) - set(removed)))
+            sorted(set(local) - set(changed) - set(removed))
+        )
 
     # Per-project tile deltas, computed once and reused by the console log, the
     # summary JSON and the PR body table.
@@ -530,14 +624,21 @@ def main():
     for p in new:
         details[p] = {"action": "new", "added": len(holdings[p]), "removed": 0}
     for p in changed:
-        details[p] = {"action": "rebuilt",
-                      "added": len(set(holdings[p]) - local[p]),
-                      "removed": len(local[p] - set(holdings[p]))}
+        details[p] = {
+            "action": "rebuilt",
+            "added": len(set(holdings[p]) - local[p]),
+            "removed": len(local[p] - set(holdings[p])),
+        }
     for p in removed:
         details[p] = {"action": "pruned", "added": 0, "removed": len(local[p])}
     for p, fields in sorted(wesm_drift.items()):
-        details[p] = {"action": "metadata", "added": 0, "removed": 0,
-                      "fields": fields, "items_updated": 0}
+        details[p] = {
+            "action": "metadata",
+            "added": 0,
+            "removed": 0,
+            "fields": fields,
+            "items_updated": 0,
+        }
 
     n_tiles_added = sum(d["added"] for d in details.values())
     n_tiles_removed = sum(d["removed"] for d in details.values())
@@ -545,9 +646,11 @@ def main():
     n_s3 = sum(len(v) for v in holdings.values())
 
     print(f"\ncatalog items: {n_local}  |  S3 tifs: {n_s3}")
-    print(f"diff: +{n_tiles_added} tiles / -{n_tiles_removed} tiles  "
-          f"({len(new)} new, {len(changed)} changed, {len(removed)} removed, "
-          f"{len(wesm_drift)} metadata-only projects)")
+    print(
+        f"diff: +{n_tiles_added} tiles / -{n_tiles_removed} tiles  "
+        f"({len(new)} new, {len(changed)} changed, {len(removed)} removed, "
+        f"{len(wesm_drift)} metadata-only projects)"
+    )
     for p in new:
         print(f"  NEW      {p} ({details[p]['added']} tiles)")
     for p in changed:
@@ -558,19 +661,29 @@ def main():
         names = ", ".join(f.removeprefix("wesm:") for f in fields)
         print(f"  METADATA {p} ({names})")
     if wesm_missing:
-        print(f"  {len(wesm_missing)} cataloged collections have no WESM row "
-              f"(metadata left untouched): {', '.join(wesm_missing[:10])}"
-              + (" ..." if len(wesm_missing) > 10 else ""))
+        print(
+            f"  {len(wesm_missing)} cataloged collections have no WESM row "
+            f"(metadata left untouched): {', '.join(wesm_missing[:10])}"
+            + (" ..." if len(wesm_missing) > 10 else "")
+        )
 
     changed_any = bool(new or changed or removed or wesm_drift)
     summary = {
-        "s3_projects": len(holdings), "s3_tiles": n_s3,
-        "catalog_projects_before": len(local), "catalog_items_before": n_local,
-        "new_projects": new, "changed_projects": changed, "removed_projects": removed,
+        "s3_projects": len(holdings),
+        "s3_tiles": n_s3,
+        "catalog_projects_before": len(local),
+        "catalog_items_before": n_local,
+        "new_projects": new,
+        "changed_projects": changed,
+        "removed_projects": removed,
         "carried_empty_projects": carried_empty,
-        "metadata_projects": sorted(wesm_drift), "wesm_missing_projects": wesm_missing,
-        "tiles_added": n_tiles_added, "tiles_removed": n_tiles_removed,
-        "dry_run": args.dry_run, "build_failures": [], "metadata_failures": [],
+        "metadata_projects": sorted(wesm_drift),
+        "wesm_missing_projects": wesm_missing,
+        "tiles_added": n_tiles_added,
+        "tiles_removed": n_tiles_removed,
+        "dry_run": args.dry_run,
+        "build_failures": [],
+        "metadata_failures": [],
         "details": details,
     }
     # "+1429/-678 tiles" -- short enough for a PR/commit title on its own; a
@@ -589,18 +702,28 @@ def main():
             args.summary.write_text(json.dumps(summary, indent=1))
         return
 
-    if (n_tiles_removed > args.max_removed_tiles and not args.allow_large_removals
-            and not args.dry_run):
-        sys.exit(f"GUARDRAIL: refusing to remove {n_tiles_removed} tiles "
-                 f"(> {args.max_removed_tiles}); rerun with --allow-large-removals "
-                 "after reviewing the diff")
+    if (
+        n_tiles_removed > args.max_removed_tiles
+        and not args.allow_large_removals
+        and not args.dry_run
+    ):
+        sys.exit(
+            f"GUARDRAIL: refusing to remove {n_tiles_removed} tiles "
+            f"(> {args.max_removed_tiles}); rerun with --allow-large-removals "
+            "after reviewing the diff"
+        )
 
-    if (len(wesm_drift) > args.max_metadata_updates
-            and not args.allow_large_metadata_updates and not args.dry_run):
-        sys.exit(f"GUARDRAIL: {len(wesm_drift)} collections drifted in WESM "
-                 f"(> {args.max_metadata_updates}); a WESM schema change hits every "
-                 "collection at once -- review the diff, then rerun with "
-                 "--allow-large-metadata-updates")
+    if (
+        len(wesm_drift) > args.max_metadata_updates
+        and not args.allow_large_metadata_updates
+        and not args.dry_run
+    ):
+        sys.exit(
+            f"GUARDRAIL: {len(wesm_drift)} collections drifted in WESM "
+            f"(> {args.max_metadata_updates}); a WESM schema change hits every "
+            "collection at once -- review the diff, then rerun with "
+            "--allow-large-metadata-updates"
+        )
 
     if args.dry_run:
         print("dry run -- exiting before rebuild")
@@ -651,18 +774,25 @@ def main():
             continue
         details[p]["items_updated"] = n
         n_items_touched += n
-        print(f"  METADATA {p}: summaries updated"
-              + (f", {n} item datetimes rewritten" if n else ""), flush=True)
+        print(
+            f"  METADATA {p}: summaries updated"
+            + (f", {n} item datetimes rewritten" if n else ""),
+            flush=True,
+        )
 
     sync_root_catalog(removed=removed)
     # add new children + regenerate the meta collection (catalog/collection.json)
     import update_root_catalog
+
     update_root_catalog.update_root_catalog()
     update_root_catalog.create_root_collection()
     write_collections_txt()
     if failures:
-        print(f"WARNING: {len(failures)} project builds failed (kept previous "
-              f"version if any): {failures}", flush=True)
+        print(
+            f"WARNING: {len(failures)} project builds failed (kept previous "
+            f"version if any): {failures}",
+            flush=True,
+        )
 
     # ---------------------------------------------------------- validation
     new_urls = []
@@ -671,28 +801,39 @@ def main():
     random.shuffle(new_urls)
     n, n404, nerr = head_check(new_urls[: args.sample_new], "new/changed", args.threads)
     if n404:
-        sys.exit(f"VALIDATION: {n404}/{n} new/changed URLs return 404 -- not committing")
+        sys.exit(
+            f"VALIDATION: {n404}/{n} new/changed URLs return 404 -- not committing"
+        )
     if n and nerr > max(2, 0.1 * n):
-        sys.exit(f"VALIDATION: {nerr}/{n} new/changed HEAD checks errored -- "
-                 "network looks degraded, not committing")
+        sys.exit(
+            f"VALIDATION: {nerr}/{n} new/changed HEAD checks errored -- "
+            "network looks degraded, not committing"
+        )
 
     # sample only projects NOT successfully rebuilt this run (untouched ones,
     # carried remnants, and failed rebuilds): rebuilt projects' URLs were just
     # HEAD-checked above, and including them would bias this gate away from
     # its purpose -- catching 404 drift in projects the run didn't touch
     rebuilt_ok = {p for p in changed if p not in failures} | set(built_new)
-    carried = [(p, i) for p, ids in catalog_state(only).items()
-               for i in ids
-               if p not in rebuilt_ok and p in local and i in local.get(p, set())]
+    carried = [
+        (p, i)
+        for p, ids in catalog_state(only).items()
+        for i in ids
+        if p not in rebuilt_ok and p in local and i in local.get(p, set())
+    ]
     sample = random.sample(carried, min(args.sample_existing, len(carried)))
     urls = [u for u in (item_asset_url(p, i) for p, i in sample) if u]
     n, n404, nerr = head_check(urls, "existing", args.threads)
     if n and 100.0 * n404 / n > args.max_404_pct:
-        sys.exit(f"VALIDATION: {n404}/{n} sampled existing URLs return 404 "
-                 f"(> {args.max_404_pct}%) -- catalog/S3 disagree, not committing")
+        sys.exit(
+            f"VALIDATION: {n404}/{n} sampled existing URLs return 404 "
+            f"(> {args.max_404_pct}%) -- catalog/S3 disagree, not committing"
+        )
     if n and nerr > max(2, 0.1 * n):
-        sys.exit(f"VALIDATION: {nerr}/{n} existing HEAD checks errored -- "
-                 "network looks degraded, not committing")
+        sys.exit(
+            f"VALIDATION: {nerr}/{n} existing HEAD checks errored -- "
+            "network looks degraded, not committing"
+        )
 
     # ------------------------------------------------------------- summary
     parts = [f"+{n_tiles_added}/-{n_tiles_removed} tiles"]
@@ -712,22 +853,35 @@ def main():
     changelog = "; ".join(parts)
 
     n_after = sum(len(v) for v in catalog_state(only).values())
-    summary.update({
-        "catalog_items_after": n_after, "build_failures": failures,
-        "metadata_projects": metadata_done, "metadata_failures": metadata_failures,
-        "metadata_items_updated": n_items_touched,
-        "changelog": changelog, "elapsed_s": round(time.time() - t0, 1),
-    })
+    summary.update(
+        {
+            "catalog_items_after": n_after,
+            "build_failures": failures,
+            "metadata_projects": metadata_done,
+            "metadata_failures": metadata_failures,
+            "metadata_items_updated": n_items_touched,
+            "changelog": changelog,
+            "elapsed_s": round(time.time() - t0, 1),
+        }
+    )
     if args.summary:
         args.summary.write_text(json.dumps(summary, indent=1))
     if args.pr_body:
         args.pr_body.write_text(render_pr_body(summary, run_url()))
     # `title` and `subject` stay short enough to read in a PR list / git log;
     # the exhaustive project list lives in the PR body table and the summary JSON
-    subject = (f"{title} ({len(new)} new, {len(changed)} rebuilt, "
-               f"{len(removed)} pruned, {len(metadata_done)} metadata)")
-    github_output(changed="true", changelog=changelog, title=title,
-                  subject=subject, n_items=n_after, n_failures=len(failures))
+    subject = (
+        f"{title} ({len(new)} new, {len(changed)} rebuilt, "
+        f"{len(removed)} pruned, {len(metadata_done)} metadata)"
+    )
+    github_output(
+        changed="true",
+        changelog=changelog,
+        title=title,
+        subject=subject,
+        n_items=n_after,
+        n_failures=len(failures),
+    )
     print(f"\nrefresh complete in {summary['elapsed_s']}s: {changelog}")
     print(f"catalog items: {n_local} -> {n_after}")
 

--- a/scripts/update_root_catalog.py
+++ b/scripts/update_root_catalog.py
@@ -14,19 +14,19 @@ def get_subcollections(base_path="./catalog"):
 
 
 def update_root_catalog(base_path="./catalog"):
-    path = f'{base_path}/catalog.json'
+    path = f"{base_path}/catalog.json"
     cat = pystac.read_file(path)
     subcats = get_subcollections(base_path)
     existing = [subcat.id for subcat in list(cat.get_children())]
     new = [x for x in subcats if x.id not in existing]
     cat.add_children(new)
     cat.save_object(include_self_link=False, dest_href=path)
-    print(f'Updated {path}')
+    print(f"Updated {path}")
 
 
 def create_root_collection(base_path="./catalog"):
-    ''' render all processed bboxes on a map'''
-    output = f'{base_path}/collection.json'
+    """render all processed bboxes on a map"""
+    output = f"{base_path}/collection.json"
     collections = get_subcollections(base_path)
     bboxes = [c.extent.spatial.bboxes[0] for c in collections]
     intervals = [c.extent.temporal.intervals[0] for c in collections]
@@ -43,20 +43,19 @@ def create_root_collection(base_path="./catalog"):
     bboxes.insert(0, overall_bbox)
 
     spatial_extents = pystac.SpatialExtent(bboxes=bboxes)
-    temporal_extent = pystac.TemporalExtent(
-        intervals=[min(times), max(times)]
-    )
+    temporal_extent = pystac.TemporalExtent(intervals=[min(times), max(times)])
     collection_extent = pystac.Extent(spatial=spatial_extents, temporal=temporal_extent)
 
     collection = pystac.Collection(
-        id='All Cataloged',
+        id="All Cataloged",
         description="Meta collection of all 1m DEM STAC collections in this catalog.",
         providers=collections[0].providers,
         extent=collection_extent,
         license=collections[0].license,
     )
     collection.save_object(include_self_link=False, dest_href=output)
-    print(f'Updated {output}')
+    print(f"Updated {output}")
+
 
 if __name__ == "__main__":
     update_root_catalog()


### PR DESCRIPTION
`pixi run ruff` had no scope, so every invocation walked the whole repo. In practice that meant:

- ~40 syntax errors reported from `notebooks/` and `checkpoints/` cells that hold pasted shell output and GDAL logs (`Warning 1: Tile index is out of sync ...` is not Python);
- and, on the last run, **7 notebooks reformatted** that nobody asked it to touch.

## Changes

**`ruff.toml`** — whitelists `scripts/**/*.py`. Whitelisting rather than excluding `notebooks/`/`checkpoints/` also keeps stray `.py`/`.ipynb` files at the repo root out of scope. Ruff now sees 8 files instead of the whole tree, and the scope is identical however it's invoked — pixi task, CI, or editor.

**`pixi run lint`** — `ruff check --output-format=github && ruff format --diff`. Mutates nothing, annotates offending lines on the PR diff, exits non-zero on either a lint error or a formatting difference. `pixi run ruff` remains the fix-it-for-me task.

**`.github/workflows/lint.yml`** — runs `pixi run lint` on every PR and push to `main`.

**Formatting backfill** — applies `ruff format` to the 5 scripts that were not yet formatted. Quotes and line wrapping only, no behavior change; separable from the rest of the diff if you'd rather land it on its own.

## Verification

| case | result |
| --- | --- |
| clean tree | `8 files already formatted`, exit 0 |
| lint error (`import os` unused, misplaced) | GitHub annotations emitted, exit 1 |
| formatting-only difference (`x   =  1`) | diff printed, exit 1 |
| notebooks present in tree | untouched — not in ruff's file set |

## Note

This PR does not include the 7 notebooks that the earlier unscoped run reformatted; they're still modified in the working tree, mixed in with pre-existing edits. Four of them (`CO_WestCentral_2019_A19`, `sierras-metadata`, `collection-properties`, `validation-orig`) are untracked, so git can't restore those — worth a look before committing anything under `notebooks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)