### PR TITLE
Reuse existing items on rebuild; never let one bad tile kill a build

### DIFF
--- a/scripts/create_static_stac.py
+++ b/scripts/create_static_stac.py
@@ -179,14 +179,33 @@ def create_stac_item(URL, DATETIME):
         print(r.status_code)
         print(r.text)
 
-        if r.status_code == 500:
-            if r.json().get("detail", "").startswith("Too many bins for data range"):
-                params["with_raster"] = "false"
-                r = requests.get(stacify, params=params, timeout=TIMEOUT)
+        # NOTE: match on r.text, not r.json(). A 502 body is plain text
+        # ("Internal Server Error"), so r.json() raised JSONDecodeError here.
+        if r.status_code == 500 and "Too many bins for data range" in r.text:
+            params["with_raster"] = "false"
+            r = requests.get(stacify, params=params, timeout=TIMEOUT)
         else:  # internal server errors seem to be 502?
             # just retry after a moment
             time.sleep(1)
             r = requests.get(stacify, params=params, timeout=TIMEOUT)
+
+        # Statistics are what titiler actually chokes on: it asks GDAL for a
+        # decimated read (max_size=1024), which is a few hundred KB off a COG
+        # overview but a full-resolution pass over a re-staged non-COG -- e.g.
+        # TX_WestTexas_2018_D19's two uncompressed, un-overviewed, 148 MB
+        # tiles, which 502 every time. Drop the stats before giving up.
+        if r.status_code != 200 and params.get("with_raster") != "false":
+            print(f"{ID}: retrying without raster statistics")
+            params["with_raster"] = "false"
+            r = requests.get(stacify, params=params, timeout=TIMEOUT)
+
+        # Never return an unvalidated body: it used to surface ~1000 tiles
+        # later as an opaque JSONDecodeError from json.loads("Internal Server
+        # Error"), taking the whole collection build down with it.
+        if r.status_code != 200:
+            raise RuntimeError(
+                f"titiler HTTP {r.status_code} for {URL}: {r.text[:200]!r}"
+            )
 
     return r.text
 
@@ -344,8 +363,8 @@ def normalize_projection(item_dict):
 
 
 # TODO: can probably speed this up a lot just by taking min/max of bboxes
-def get_collection_bbox(results):
-    gf = gpd.GeoDataFrame.from_features([json.loads(x) for x in results])
+def get_collection_bbox(item_dicts):
+    gf = gpd.GeoDataFrame.from_features(item_dicts)
     return gf.total_bounds.tolist()
 
 
@@ -365,7 +384,43 @@ def list_tiffs_in_project(project, bucket="prd-tnm"):
     return [f"https://{bucket}.s3.amazonaws.com/{key}" for key in tiff_files]
 
 
-def create_stac_catalog(project, is_workunit=False):
+def reusable_items(project, datetime_str, full=False):
+    """{item_id: item dict} for items already in catalog/<project>.
+
+    A rebuild is triggered by the tile *set* changing, but re-deriving all ~1000
+    existing items from titiler to pick up 22 new ones is both slow and fragile:
+    one tile titiler cannot answer for kills the whole collection (issue: two of
+    TX_WestTexas_2018_D19's tiles were re-staged as 148 MB non-COGs and 502 on
+    every statistics request). Everything titiler derives from a tile -- geometry,
+    projection, raster stats -- is a function of that tile alone, so an unchanged
+    tile's item can be reused as is. Only the datetimes come from WESM, and those
+    are restamped here so an incremental rebuild ends up where a full one would.
+
+    full=True re-derives everything from titiler instead (after a titiler
+    upgrade, or to pick up tiles whose pixels were re-staged in place).
+    """
+    if full:
+        return {}
+    start, end = datetime_str.split("/")
+    items = {}
+    for path in sorted(Path(f"./catalog/{project}").glob("*.json")):
+        if path.name == "collection.json":
+            continue
+        try:
+            item = json.loads(path.read_text())
+        except Exception:
+            continue  # unreadable -> let titiler rebuild it
+        item["properties"]["start_datetime"] = start
+        item["properties"]["end_datetime"] = end
+        # drop the on-disk root/collection/parent links: they are relative
+        # ("./collection.json") and unresolvable until the item has an href, and
+        # collection.add_items() + normalize_hrefs() rewrite them regardless
+        item["links"] = []
+        items[path.stem] = item
+    return items
+
+
+def create_stac_catalog(project, is_workunit=False, full=False):
     """Create a STAC catalog from a 3DEP 1m project"""
     s = get_wesm_series(project, is_workunit=is_workunit)
 
@@ -379,13 +434,23 @@ def create_stac_catalog(project, is_workunit=False):
     if len(tiflist) == 0:
         raise ValueError(f"No tiffs found for project '{project}'")
 
-    print(f"creating STAC Items from {len(tiflist)} tifs...")
     # Same datatime range for all tifs in a project
     # Formatted for TITILER 2019-08-21T00:00:00Z/2019-09-19T00:00:00Z'
     DATETIME = get_titiler_datetime(s)
 
+    reused = reusable_items(project, DATETIME, full=full)
+    todo = [url for url in tiflist if url.split("/")[-1][:-4] not in reused]
+    # tiles that vanished upstream are simply not in tiflist, so they drop out
+    reused = {
+        i: d for i, d in reused.items() if i in {u.split("/")[-1][:-4] for u in tiflist}
+    }
+    print(
+        f"creating STAC Items from {len(tiflist)} tifs "
+        f"({len(todo)} from titiler, {len(reused)} reused)..."
+    )
+
     # ASYNC
-    results = generate_stac_from_titiler(tiflist, DATETIME)
+    results = generate_stac_from_titiler(todo, DATETIME) if todo else []
 
     # SYNC
     # results = []
@@ -422,11 +487,15 @@ def create_stac_catalog(project, is_workunit=False):
     #     item = pystac.read_dict(json.loads(x))
     #     print(item.id)
     #     items.append(item)
-    items = [pystac.read_dict(normalize_projection(json.loads(x))) for x in results]
+    # normalize_projection() on the titiler responses only: reused items came
+    # out of the catalog, which is already uniformly projection v2.0.0
+    item_dicts = [normalize_projection(json.loads(x)) for x in results]
+    item_dicts += list(reused.values())
+    items = [pystac.read_dict(d) for d in item_dicts]
 
     # THis will be 'collection' level metadata, not in each item
     # [add_wesm_metadata_to_properties(item, s) for item in items]
-    collection_bbox = get_collection_bbox(results)
+    collection_bbox = get_collection_bbox(item_dicts)
 
     # extent either from metadata or geodataframe
     # Probably fastest to get it from WESM GPKG from fid lookup
@@ -506,7 +575,16 @@ if __name__ == "__main__":
         "--overwrite",
         action="store_true",
         default=False,
-        help="Overwrite existing project folder if it exists",
+        help="Overwrite existing project folder if it exists "
+        "(items already present are reused; only new tiles hit titiler)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        default=False,
+        help="With --overwrite, re-derive every item from titiler instead of "
+        "reusing existing ones (after a titiler upgrade, or to pick up tiles "
+        "whose pixels were re-staged in place)",
     )
     args = parser.parse_args()
 
@@ -525,8 +603,8 @@ if __name__ == "__main__":
     if stac_path.exists():
         if args.overwrite:
             print(f"Overwriting existing project folder '{project}'.")
-            create_stac_catalog(project, is_workunit)
+            create_stac_catalog(project, is_workunit, full=args.full)
         else:
             print(f"Output folder '{project}' already exists, skipping.")
     else:
-        create_stac_catalog(project, is_workunit)
+        create_stac_catalog(project, is_workunit, full=args.full)

--- a/scripts/refresh_catalog.py
+++ b/scripts/refresh_catalog.py
@@ -256,16 +256,20 @@ def refresh_collection_metadata(project, series):
 
 
 # ------------------------------------------------------------------ rebuild
-def build_project(project, overwrite=False):
+def build_project(project, overwrite=False, full=False):
     """Run create_static_stac.py for one project; True on success.
 
     Mirrors create_all.py: try as WESM workunit first, then as project.
+    A rebuild reuses the items already on disk and asks titiler only about new
+    tiles; full=True re-derives every item instead (see --full-rebuild).
     """
     script = Path(__file__).parent / "create_static_stac.py"
     for flag in ("--workunit", "--project"):
         cmd = [sys.executable, str(script), flag, project]
         if overwrite:
             cmd.append("--overwrite")
+        if full:
+            cmd.append("--full")
         try:
             subprocess.run(cmd, check=True)
             return True
@@ -510,6 +514,13 @@ def main():
         "--allow-large-removals",
         action="store_true",
         help="override --max-removed-tiles after human review",
+    )
+    ap.add_argument(
+        "--full-rebuild",
+        action="store_true",
+        help="re-derive every item of a rebuilt project from titiler instead of "
+        "reusing unchanged ones (slow: one request per tile, and it re-reads "
+        "tiles titiler may no longer be able to answer for)",
     )
     ap.add_argument(
         "--skip-wesm-check",
@@ -759,7 +770,7 @@ def main():
         if not build_project(p):
             failures.append(p)
     for p in changed:
-        if not build_project(p, overwrite=True):
+        if not build_project(p, overwrite=True, full=args.full_rebuild):
             failures.append(p)
     for p in removed:
         prune_project(p)


### PR DESCRIPTION
`TX_WestTexas_2018_D19` has failed every refresh since February, and would have kept failing forever. Diagnosis and two independent fixes.

## Why it fails

Two of that project's 1,021 tiles were re-staged by USGS on **2026-02-14** — the bulk prefix rewrite from #6 — and the new copies are not COGs:

| | failing tile `x66y321` | control tile `x50y338` |
| --- | --- | --- |
| pixels | 10012 × 3870 | 10012 × 10012 — **2.6× more** |
| block | **10012 × 1** (striped) | 256 × 256 (tiled) |
| compression | **none** | LZW |
| overviews | **none** | 5 levels, to 313 × 313 |
| bytes on S3 | **148 MB** | 7 MB |

It is not the size. titiler asks for the same decimated read either way — the committed histogram buckets sum to 88,496 valid samples, which at 21.82% valid implies ~405,500 pixels sampled, and 1024 × 396 = 405,504, i.e. titiler's default `max_size=1024`. On a COG, GDAL serves that from an overview in milliseconds. With no overviews it must read all 148 MB at full resolution and decimate in memory, and the Lambda gives up at ~10 s → 502. Confirmed live: `with_raster=true` → 502 after 10.2 s; `with_raster=false` → 200 in 0.4 s.

**The pixels did not change** — this was a repackaging. Full-resolution stats on the current file versus the committed ones: minimum identical to the last digit, mean Δ 0.0008, stddev Δ 0.0004, max Δ 0.22 (a decimated read misses the single highest pixel). So the `raster:bands` statistics already in the catalog are still valid and worth preserving.

## Fix 1 — rebuild incrementally

A rebuild re-derived all 1,021 items from titiler in order to pick up 22 new tiles. Everything titiler returns — geometry, projection, raster stats — is a function of the tile alone, so an unchanged tile's item can be reused as is. Only the datetimes come from WESM, and `reusable_items()` restamps those from the live row, so **an incremental rebuild lands exactly where a full one would**.

The two unreadable tiles are simply never requested, and their still-valid statistics survive.

`--full` (`create_static_stac.py`) / `--full-rebuild` (`refresh_catalog.py`) forces the old behavior, for when re-deriving is the point — a titiler upgrade, or picking up tiles whose pixels were genuinely re-staged.

## Fix 2 — stop one bad response killing the build

`create_stac_item` returned `r.text` without checking it, so a plain-text 502 body surfaced ~1,000 tiles later as `JSONDecodeError` from `json.loads("Internal Server Error")` — inside a list comprehension over every result, so two bad tiles out of 1,021 aborted the entire collection. Also, the `r.status_code == 500` branch called `r.json()`, which raises on exactly the non-JSON body it was trying to inspect.

Now: match `"Too many bins"` on `r.text`; fall back to `with_raster=false` on any persistent error; and raise a `RuntimeError` naming the tile and status if it still fails, instead of returning a body that dies far away with an opaque error.

Worth keeping even with Fix 1, since Fix 1 only avoids tiles that are *already* catalogued — a newly staged bad tile still needs this.

## Verification

| check | result |
| --- | --- |
| rebuild `TX_WestTexas_2018_D19` (was failing every run) | **1,021 items in 3.8 s** — 22 from titiler, 999 reused |
| items added / dropped | 22 / 0 |
| the two problem tiles | differ only in `end_datetime`; `raster:bands` intact |
| new items | valid `proj:code`, raster stats, correct datetimes |
| fresh build of `NM_RioSanJose_2016` (no existing items) | 1 from titiler, 0 reused |
| `--full` rebuild of same | 1 from titiler, 0 reused; item **and** `collection.json` byte-identical to what is committed |
| `create_stac_item` on the 502 tile | returns parseable JSON (no statistics) instead of raising |

## Follow-on worth noting

This is a live instance of **Gap 1** in [docs/check-consistency.md](docs/check-consistency.md) — content drift, same key, new bytes, invisible to a set diff. Here it turned out benign (packaging only), but nothing in the catalog would have told us that; it took a manual full-resolution stats comparison. The `file:size` / `file:checksum` proposal in that doc is what would make it detectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)